### PR TITLE
feat: Generate nginx config and ingress integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -173,3 +173,6 @@ cython_debug/
 .pypirc
 
 *.charm
+
+# PyCharm
+.idea/

--- a/coordinator/charmcraft.yaml
+++ b/coordinator/charmcraft.yaml
@@ -93,6 +93,12 @@ requires:
     interface: catalogue
     description: |
       Integration to help users discover Pyroscope's UI.
+  ingress:
+    interface: ingress
+    optional: true
+    limit: 1
+    description: |
+      Ingress-per-app, to load-balance across multiple units of the coordinator.
 
 peers:
   peers:

--- a/coordinator/lib/charms/traefik_k8s/v2/ingress.py
+++ b/coordinator/lib/charms/traefik_k8s/v2/ingress.py
@@ -1,0 +1,914 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+r"""# Interface Library for ingress.
+
+This library wraps relation endpoints using the `ingress` interface
+and provides a Python API for both requesting and providing per-application
+ingress, with load-balancing occurring across all units.
+
+## Getting Started
+
+To get started using the library, you just need to fetch the library using `charmcraft`.
+
+```shell
+cd some-charm
+charmcraft fetch-lib charms.traefik_k8s.v2.ingress
+```
+
+In the `metadata.yaml` of the charm, add the following:
+
+```yaml
+requires:
+    ingress:
+        interface: ingress
+        limit: 1
+```
+
+Then, to initialise the library:
+
+```python
+from charms.traefik_k8s.v2.ingress import (IngressPerAppRequirer,
+  IngressPerAppReadyEvent, IngressPerAppRevokedEvent)
+
+class SomeCharm(CharmBase):
+  def __init__(self, *args):
+    # ...
+    self.ingress = IngressPerAppRequirer(self, port=80)
+    # The following event is triggered when the ingress URL to be used
+    # by this deployment of the `SomeCharm` is ready (or changes).
+    self.framework.observe(
+        self.ingress.on.ready, self._on_ingress_ready
+    )
+    self.framework.observe(
+        self.ingress.on.revoked, self._on_ingress_revoked
+    )
+
+    def _on_ingress_ready(self, event: IngressPerAppReadyEvent):
+        logger.info("This app's ingress URL: %s", event.url)
+
+    def _on_ingress_revoked(self, event: IngressPerAppRevokedEvent):
+        logger.info("This app no longer has ingress")
+"""
+import ipaddress
+import json
+import logging
+import socket
+import typing
+from dataclasses import dataclass
+from functools import partial
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    List,
+    MutableMapping,
+    Optional,
+    Sequence,
+    Tuple,
+    Union,
+    cast,
+)
+
+import pydantic
+from ops.charm import CharmBase, RelationBrokenEvent, RelationEvent
+from ops.framework import EventSource, Object, ObjectEvents, StoredState
+from ops.model import ModelError, Relation, Unit
+from pydantic import AnyHttpUrl, BaseModel, Field
+
+# The unique Charmhub library identifier, never change it
+LIBID = "e6de2a5cd5b34422a204668f3b8f90d2"
+
+# Increment this major API version when introducing breaking changes
+LIBAPI = 2
+
+# Increment this PATCH version before using `charmcraft publish-lib` or reset
+# to 0 if you are raising the major API version
+LIBPATCH = 15
+
+PYDEPS = ["pydantic"]
+
+DEFAULT_RELATION_NAME = "ingress"
+RELATION_INTERFACE = "ingress"
+
+log = logging.getLogger(__name__)
+BUILTIN_JUJU_KEYS = {"ingress-address", "private-address", "egress-subnets"}
+
+PYDANTIC_IS_V1 = int(pydantic.version.VERSION.split(".")[0]) < 2
+if PYDANTIC_IS_V1:
+    from pydantic import validator
+
+    input_validator = partial(validator, pre=True)
+
+    class DatabagModel(BaseModel):  # type: ignore
+        """Base databag model."""
+
+        class Config:
+            """Pydantic config."""
+
+            allow_population_by_field_name = True
+            """Allow instantiating this class by field name (instead of forcing alias)."""
+
+        _NEST_UNDER = None
+
+        @classmethod
+        def load(cls, databag: MutableMapping):
+            """Load this model from a Juju databag."""
+            if cls._NEST_UNDER:
+                return cls.parse_obj(json.loads(databag[cls._NEST_UNDER]))
+
+            try:
+                data = {
+                    k: json.loads(v)
+                    for k, v in databag.items()
+                    # Don't attempt to parse model-external values
+                    if k in {f.alias for f in cls.__fields__.values()}  # type: ignore
+                }
+            except json.JSONDecodeError as e:
+                msg = f"invalid databag contents: expecting json. {databag}"
+                log.error(msg)
+                raise DataValidationError(msg) from e
+
+            try:
+                return cls.parse_raw(json.dumps(data))  # type: ignore
+            except pydantic.ValidationError as e:
+                msg = f"failed to validate databag: {databag}"
+                log.debug(msg, exc_info=True)
+                raise DataValidationError(msg) from e
+
+        def dump(self, databag: Optional[MutableMapping] = None, clear: bool = True):
+            """Write the contents of this model to Juju databag.
+
+            :param databag: the databag to write the data to.
+            :param clear: ensure the databag is cleared before writing it.
+            """
+            if clear and databag:
+                databag.clear()
+
+            if databag is None:
+                databag = {}
+
+            if self._NEST_UNDER:
+                databag[self._NEST_UNDER] = self.json(by_alias=True, exclude_defaults=True)
+                return databag
+
+            for key, value in self.dict(by_alias=True, exclude_defaults=True).items():  # type: ignore
+                databag[key] = json.dumps(value)
+
+            return databag
+
+else:
+    from pydantic import ConfigDict, field_validator
+
+    input_validator = partial(field_validator, mode="before")
+
+    class DatabagModel(BaseModel):
+        """Base databag model."""
+
+        model_config = ConfigDict(
+            # tolerate additional keys in databag
+            extra="ignore",
+            # Allow instantiating this class by field name (instead of forcing alias).
+            populate_by_name=True,
+            # Custom config key: whether to nest the whole datastructure (as json)
+            # under a field or spread it out at the toplevel.
+            _NEST_UNDER=None,
+        )  # type: ignore
+        """Pydantic config."""
+
+        @classmethod
+        def load(cls, databag: MutableMapping):
+            """Load this model from a Juju databag."""
+            nest_under = cls.model_config.get("_NEST_UNDER")
+            if nest_under:
+                return cls.model_validate(json.loads(databag[nest_under]))  # type: ignore
+
+            try:
+                data = {
+                    k: json.loads(v)
+                    for k, v in databag.items()
+                    # Don't attempt to parse model-external values
+                    if k in {(f.alias or n) for n, f in cls.model_fields.items()}  # type: ignore
+                }
+            except json.JSONDecodeError as e:
+                msg = f"invalid databag contents: expecting json. {databag}"
+                log.error(msg)
+                raise DataValidationError(msg) from e
+
+            try:
+                return cls.model_validate_json(json.dumps(data))  # type: ignore
+            except pydantic.ValidationError as e:
+                msg = f"failed to validate databag: {databag}"
+                log.debug(msg, exc_info=True)
+                raise DataValidationError(msg) from e
+
+        def dump(self, databag: Optional[MutableMapping] = None, clear: bool = True):
+            """Write the contents of this model to Juju databag.
+
+            :param databag: the databag to write the data to.
+            :param clear: ensure the databag is cleared before writing it.
+            """
+            if clear and databag:
+                databag.clear()
+
+            if databag is None:
+                databag = {}
+            nest_under = self.model_config.get("_NEST_UNDER")
+            if nest_under:
+                databag[nest_under] = self.model_dump_json(  # type: ignore
+                    by_alias=True,
+                    # skip keys whose values are default
+                    exclude_defaults=True,
+                )
+                return databag
+
+            dct = self.model_dump(mode="json", by_alias=True, exclude_defaults=True)  # type: ignore
+            databag.update({k: json.dumps(v) for k, v in dct.items()})
+            return databag
+
+
+# todo: import these models from charm-relation-interfaces/ingress/v2 instead of redeclaring them
+class IngressUrl(BaseModel):
+    """Ingress url schema."""
+
+    url: AnyHttpUrl
+
+
+class IngressProviderAppData(DatabagModel):
+    """Ingress application databag schema."""
+
+    ingress: Optional[IngressUrl] = None
+
+
+class ProviderSchema(BaseModel):
+    """Provider schema for Ingress."""
+
+    app: IngressProviderAppData
+
+
+class IngressHealthCheck(BaseModel):
+    """HealthCheck schema for Ingress."""
+
+    path: str = Field(description="The health check endpoint path (required).")
+    scheme: Optional[str] = Field(
+        default=None, description="Replaces the server URL scheme for the health check endpoint."
+    )
+    hostname: Optional[str] = Field(
+        default=None, description="Hostname to be set in the health check request."
+    )
+    port: Optional[int] = Field(
+        default=None, description="Replaces the server URL port for the health check endpoint."
+    )
+    interval: str = Field(default="30s", description="Frequency of the health check calls.")
+    timeout: str = Field(default="5s", description="Maximum duration for a health check request.")
+
+
+class IngressRequirerAppData(DatabagModel):
+    """Ingress requirer application databag model."""
+
+    model: str = Field(description="The model the application is in.")
+    name: str = Field(description="the name of the app requesting ingress.")
+    port: int = Field(description="The port the app wishes to be exposed.")
+    healthcheck_params: Optional[IngressHealthCheck] = Field(
+        default=None, description="Optional health check configuration for ingress."
+    )
+
+    # fields on top of vanilla 'ingress' interface:
+    strip_prefix: Optional[bool] = Field(
+        default=False,
+        description="Whether to strip the prefix from the ingress url.",
+        alias="strip-prefix",
+    )
+    redirect_https: Optional[bool] = Field(
+        default=False,
+        description="Whether to redirect http traffic to https.",
+        alias="redirect-https",
+    )
+
+    scheme: Optional[str] = Field(
+        default="http", description="What scheme to use in the generated ingress url"
+    )
+
+    @input_validator("scheme")
+    def validate_scheme(cls, scheme):  # noqa: N805  # pydantic wants 'cls' as first arg
+        """Validate scheme arg."""
+        if scheme not in {"http", "https", "h2c"}:
+            raise ValueError("invalid scheme: should be one of `http|https|h2c`")
+        return scheme
+
+    @input_validator("port")
+    def validate_port(cls, port):  # noqa: N805  # pydantic wants 'cls' as first arg
+        """Validate port."""
+        assert isinstance(port, int), type(port)
+        assert 0 < port < 65535, "port out of TCP range"
+        return port
+
+
+class IngressRequirerUnitData(DatabagModel):
+    """Ingress requirer unit databag model."""
+
+    host: str = Field(description="Hostname at which the unit is reachable.")
+    ip: Optional[str] = Field(
+        None,
+        description="IP at which the unit is reachable, "
+        "IP can only be None if the IP information can't be retrieved from juju.",
+    )
+
+    @input_validator("host")
+    def validate_host(cls, host):  # noqa: N805  # pydantic wants 'cls' as first arg
+        """Validate host."""
+        assert isinstance(host, str), type(host)
+        return host
+
+    @input_validator("ip")
+    def validate_ip(cls, ip):  # noqa: N805  # pydantic wants 'cls' as first arg
+        """Validate ip."""
+        if ip is None:
+            return None
+        if not isinstance(ip, str):
+            raise TypeError(f"got ip of type {type(ip)} instead of expected str")
+        try:
+            ipaddress.IPv4Address(ip)
+            return ip
+        except ipaddress.AddressValueError:
+            pass
+        try:
+            ipaddress.IPv6Address(ip)
+            return ip
+        except ipaddress.AddressValueError:
+            raise ValueError(f"{ip!r} is not a valid ip address")
+
+
+class RequirerSchema(BaseModel):
+    """Requirer schema for Ingress."""
+
+    app: IngressRequirerAppData
+    unit: IngressRequirerUnitData
+
+
+class IngressError(RuntimeError):
+    """Base class for custom errors raised by this library."""
+
+
+class NotReadyError(IngressError):
+    """Raised when a relation is not ready."""
+
+
+class DataValidationError(IngressError):
+    """Raised when data validation fails on IPU relation data."""
+
+
+class _IngressPerAppBase(Object):
+    """Base class for IngressPerUnit interface classes."""
+
+    def __init__(self, charm: CharmBase, relation_name: str = DEFAULT_RELATION_NAME):
+        super().__init__(charm, relation_name)
+
+        self.charm: CharmBase = charm
+        self.relation_name = relation_name
+        self.app = self.charm.app
+        self.unit = self.charm.unit
+
+        observe = self.framework.observe
+        rel_events = charm.on[relation_name]
+        observe(rel_events.relation_created, self._handle_relation)
+        observe(rel_events.relation_joined, self._handle_relation)
+        observe(rel_events.relation_changed, self._handle_relation)
+        observe(rel_events.relation_departed, self._handle_relation)
+        observe(rel_events.relation_broken, self._handle_relation_broken)
+        observe(charm.on.leader_elected, self._handle_upgrade_or_leader)  # type: ignore
+        observe(charm.on.upgrade_charm, self._handle_upgrade_or_leader)  # type: ignore
+
+    @property
+    def relations(self):
+        """The list of Relation instances associated with this endpoint."""
+        return list(self.charm.model.relations[self.relation_name])
+
+    def _handle_relation(self, event):
+        """Subclasses should implement this method to handle a relation update."""
+        pass
+
+    def _handle_relation_broken(self, event):
+        """Subclasses should implement this method to handle a relation breaking."""
+        pass
+
+    def _handle_upgrade_or_leader(self, event):
+        """Subclasses should implement this method to handle upgrades or leadership change."""
+        pass
+
+
+class _IPAEvent(RelationEvent):
+    __args__: Tuple[str, ...] = ()
+    __optional_kwargs__: Dict[str, Any] = {}
+
+    @classmethod
+    def __attrs__(cls):
+        return cls.__args__ + tuple(cls.__optional_kwargs__.keys())
+
+    def __init__(self, handle, relation, *args, **kwargs):
+        super().__init__(handle, relation)
+
+        if not len(self.__args__) == len(args):
+            raise TypeError("expected {} args, got {}".format(len(self.__args__), len(args)))
+
+        for attr, obj in zip(self.__args__, args):
+            setattr(self, attr, obj)
+        for attr, default in self.__optional_kwargs__.items():
+            obj = kwargs.get(attr, default)
+            setattr(self, attr, obj)
+
+    def snapshot(self):
+        dct = super().snapshot()
+        for attr in self.__attrs__():
+            obj = getattr(self, attr)
+            try:
+                dct[attr] = obj
+            except ValueError as e:
+                raise ValueError(
+                    "cannot automagically serialize {}: "
+                    "override this method and do it "
+                    "manually.".format(obj)
+                ) from e
+
+        return dct
+
+    def restore(self, snapshot) -> None:
+        super().restore(snapshot)
+        for attr, obj in snapshot.items():
+            setattr(self, attr, obj)
+
+
+class IngressPerAppDataProvidedEvent(_IPAEvent):
+    """Event representing that ingress data has been provided for an app."""
+
+    __args__ = ("name", "model", "hosts", "strip_prefix", "redirect_https")
+
+    if typing.TYPE_CHECKING:
+        name: Optional[str] = None
+        model: Optional[str] = None
+        # sequence of hostname, port dicts
+        hosts: Sequence["IngressRequirerUnitData"] = ()
+        strip_prefix: bool = False
+        redirect_https: bool = False
+
+
+class IngressPerAppDataRemovedEvent(RelationEvent):
+    """Event representing that ingress data has been removed for an app."""
+
+
+class IngressPerAppProviderEvents(ObjectEvents):
+    """Container for IPA Provider events."""
+
+    data_provided = EventSource(IngressPerAppDataProvidedEvent)
+    data_removed = EventSource(IngressPerAppDataRemovedEvent)
+
+
+@dataclass
+class IngressRequirerData:
+    """Data exposed by the ingress requirer to the provider."""
+
+    app: "IngressRequirerAppData"
+    units: List["IngressRequirerUnitData"]
+
+
+class IngressPerAppProvider(_IngressPerAppBase):
+    """Implementation of the provider of ingress."""
+
+    on = IngressPerAppProviderEvents()  # type: ignore
+
+    def __init__(
+        self,
+        charm: CharmBase,
+        relation_name: str = DEFAULT_RELATION_NAME,
+    ):
+        """Constructor for IngressPerAppProvider.
+
+        Args:
+            charm: The charm that is instantiating the instance.
+            relation_name: The name of the relation endpoint to bind to
+                (defaults to "ingress").
+        """
+        super().__init__(charm, relation_name)
+
+    def _handle_relation(self, event):
+        # created, joined or changed: if remote side has sent the required data:
+        # notify listeners.
+        if self.is_ready(event.relation):
+            data = self.get_data(event.relation)
+            self.on.data_provided.emit(  # type: ignore
+                event.relation,
+                data.app.name,
+                data.app.model,
+                [
+                    unit.dict() if PYDANTIC_IS_V1 else unit.model_dump(mode="json")
+                    for unit in data.units
+                ],
+                data.app.strip_prefix or False,
+                data.app.redirect_https or False,
+            )
+
+    def _handle_relation_broken(self, event):
+        self.on.data_removed.emit(event.relation)  # type: ignore
+
+    def wipe_ingress_data(self, relation: Relation):
+        """Clear ingress data from relation."""
+        assert self.unit.is_leader(), "only leaders can do this"
+        try:
+            relation.data
+        except ModelError as e:
+            log.warning(
+                "error {} accessing relation data for {!r}. "
+                "Probably a ghost of a dead relation is still "
+                "lingering around.".format(e, relation.name)
+            )
+            return
+        del relation.data[self.app]["ingress"]
+
+    def _get_requirer_units_data(self, relation: Relation) -> List["IngressRequirerUnitData"]:
+        """Fetch and validate the requirer's app databag."""
+        out: List["IngressRequirerUnitData"] = []
+
+        unit: Unit
+        for unit in relation.units:
+            databag = relation.data[unit]
+            try:
+                data = IngressRequirerUnitData.load(databag)
+                out.append(data)
+            except pydantic.ValidationError:
+                log.info(f"failed to validate remote unit data for {unit}")
+                raise
+        return out
+
+    @staticmethod
+    def _get_requirer_app_data(relation: Relation) -> "IngressRequirerAppData":
+        """Fetch and validate the requirer's app databag."""
+        app = relation.app
+        if app is None:
+            raise NotReadyError(relation)
+
+        databag = relation.data[app]
+        return IngressRequirerAppData.load(databag)
+
+    def get_data(self, relation: Relation) -> IngressRequirerData:
+        """Fetch the remote (requirer) app and units' databags."""
+        try:
+            return IngressRequirerData(
+                self._get_requirer_app_data(relation), self._get_requirer_units_data(relation)
+            )
+        except (pydantic.ValidationError, DataValidationError) as e:
+            raise DataValidationError("failed to validate ingress requirer data") from e
+
+    def is_ready(self, relation: Optional[Relation] = None):
+        """The Provider is ready if the requirer has sent valid data."""
+        if not relation:
+            return any(map(self.is_ready, self.relations))
+
+        try:
+            self.get_data(relation)
+        except (DataValidationError, NotReadyError) as e:
+            log.debug("Provider not ready; validation error encountered: %s" % str(e))
+            return False
+        return True
+
+    def _published_url(self, relation: Relation) -> Optional["IngressProviderAppData"]:
+        """Fetch and validate this app databag; return the ingress url."""
+        if not self.is_ready(relation) or not self.unit.is_leader():
+            # Handle edge case where remote app name can be missing, e.g.,
+            # relation_broken events.
+            # Also, only leader units can read own app databags.
+            # FIXME https://github.com/canonical/traefik-k8s-operator/issues/34
+            return None
+
+        # fetch the provider's app databag
+        databag = relation.data[self.app]
+        if not databag.get("ingress"):
+            raise NotReadyError("This application did not `publish_url` yet.")
+
+        return IngressProviderAppData.load(databag)
+
+    def publish_url(self, relation: Relation, url: str):
+        """Publish to the app databag the ingress url."""
+        ingress_url = {"url": url}
+        try:
+            IngressProviderAppData(ingress=ingress_url).dump(relation.data[self.app])  # type: ignore
+        except pydantic.ValidationError as e:
+            # If we cannot validate the url as valid, publish an empty databag and log the error.
+            log.error(f"Failed to validate ingress url '{url}' - got ValidationError {e}")
+            log.error(
+                "url was not published to ingress relation for {relation.app}.  This error is likely due to an"
+                " error or misconfiguration of the charm calling this library."
+            )
+            IngressProviderAppData(ingress=None).dump(relation.data[self.app])  # type: ignore
+
+    @property
+    def proxied_endpoints(self) -> Dict[str, Dict[str, str]]:
+        """Returns the ingress settings provided to applications by this IngressPerAppProvider.
+
+        For example, when this IngressPerAppProvider has provided the
+        `http://foo.bar/my-model.my-app` URL to the my-app application, the returned dictionary
+        will be:
+
+        ```
+        {
+            "my-app": {
+                "url": "http://foo.bar/my-model.my-app"
+            }
+        }
+        ```
+        """
+        results: Dict[str, Dict[str, str]] = {}
+
+        for ingress_relation in self.relations:
+            if not ingress_relation.app:
+                log.warning(
+                    f"no app in relation {ingress_relation} when fetching proxied endpoints: skipping"
+                )
+                continue
+            try:
+                ingress_data = self._published_url(ingress_relation)
+            except NotReadyError:
+                log.warning(
+                    f"no published url found in {ingress_relation}: "
+                    f"traefik didn't publish_url yet to this relation."
+                )
+                continue
+
+            if not ingress_data:
+                log.warning(f"relation {ingress_relation} not ready yet: try again in some time.")
+                continue
+
+            # Validation above means ingress cannot be None, but type checker doesn't know that.
+            ingress = ingress_data.ingress
+            ingress = cast(IngressProviderAppData, ingress)
+            if PYDANTIC_IS_V1:
+                results[ingress_relation.app.name] = ingress.dict()
+            else:
+                results[ingress_relation.app.name] = ingress.model_dump(mode="json")
+        return results
+
+
+class IngressPerAppReadyEvent(_IPAEvent):
+    """Event representing that ingress for an app is ready."""
+
+    __args__ = ("url",)
+    if typing.TYPE_CHECKING:
+        url: Optional[str] = None
+
+
+class IngressPerAppRevokedEvent(RelationEvent):
+    """Event representing that ingress for an app has been revoked."""
+
+
+class IngressPerAppRequirerEvents(ObjectEvents):
+    """Container for IPA Requirer events."""
+
+    ready = EventSource(IngressPerAppReadyEvent)
+    revoked = EventSource(IngressPerAppRevokedEvent)
+
+
+class IngressPerAppRequirer(_IngressPerAppBase):
+    """Implementation of the requirer of the ingress relation."""
+
+    on = IngressPerAppRequirerEvents()  # type: ignore
+
+    # used to prevent spurious urls to be sent out if the event we're currently
+    # handling is a relation-broken one.
+    _stored = StoredState()
+
+    def __init__(
+        self,
+        charm: CharmBase,
+        relation_name: str = DEFAULT_RELATION_NAME,
+        *,
+        host: Optional[str] = None,
+        ip: Optional[str] = None,
+        port: Optional[int] = None,
+        strip_prefix: bool = False,
+        redirect_https: bool = False,
+        # fixme: this is horrible UX.
+        #  shall we switch to manually calling provide_ingress_requirements with all args when ready?
+        scheme: Union[Callable[[], str], str] = lambda: "http",
+        healthcheck_params: Optional[Dict[str, Any]] = None,
+    ):
+        """Constructor for IngressRequirer.
+
+        The request args can be used to specify the ingress properties when the
+        instance is created. If any are set, at least `port` is required, and
+        they will be sent to the ingress provider as soon as it is available.
+        All request args must be given as keyword args.
+
+        Args:
+            charm: The charm that is instantiating the library.
+            relation_name: The name of the relation endpoint to bind to (defaults to "ingress");
+                the relation must be of interface type "ingress" and have a limit of 1.
+            host: Hostname to be used by the ingress provider to address the requiring
+                application; if unspecified, the default Kubernetes service name will be used.
+            ip: Alternative addressing method other than host to be used by the ingress provider;
+                if unspecified, the binding address from the Juju network API will be used.
+            healthcheck_params: Optional dictionary containing health check
+                configuration parameters conforming to the IngressHealthCheck schema. The dictionary must include:
+                    - "path" (str): The health check endpoint path (required).
+                It may also include:
+                    - "scheme" (Optional[str]): Replaces the server URL scheme for the health check endpoint.
+                    - "hostname" (Optional[str]): Hostname to be set in the health check request.
+                    - "port" (Optional[int]): Replaces the server URL port for the health check endpoint.
+                    - "interval" (str): Frequency of the health check calls (defaults to "30s" if omitted).
+                    - "timeout" (str): Maximum duration for a health check request (defaults to "5s" if omitted).
+                If provided, "path" is required while "interval" and "timeout" will use Traefik's defaults when not specified.
+            strip_prefix: Configure Traefik to strip the path prefix.
+            redirect_https: Redirect incoming requests to HTTPS.
+            scheme: Either a callable that returns the scheme to use when constructing the ingress URL,
+                or a string if the scheme is known and stable at charm initialization.
+
+        Request Args:
+            port: the port of the service
+        """
+        super().__init__(charm, relation_name)
+        self.charm: CharmBase = charm
+        self.healthcheck_params = healthcheck_params
+        self.relation_name = relation_name
+        self._strip_prefix = strip_prefix
+        self._redirect_https = redirect_https
+        self._get_scheme = scheme if callable(scheme) else lambda: scheme
+
+        self._stored.set_default(current_url=None)  # type: ignore
+
+        # if instantiated with a port, and we are related, then
+        # we immediately publish our ingress data  to speed up the process.
+        if port:
+            self._auto_data = host, ip, port
+        else:
+            self._auto_data = None
+
+    def _handle_relation(self, event):
+        # created, joined or changed: if we have auto data: publish it
+        self._publish_auto_data()
+        if self.is_ready():
+            # Avoid spurious events, emit only when there is a NEW URL available
+            new_url = (
+                None
+                if isinstance(event, RelationBrokenEvent)
+                else self._get_url_from_relation_data()
+            )
+            if self._stored.current_url != new_url:  # type: ignore
+                self._stored.current_url = new_url  # type: ignore
+                self.on.ready.emit(event.relation, new_url)  # type: ignore
+
+    def _handle_relation_broken(self, event):
+        self._stored.current_url = None  # type: ignore
+        self.on.revoked.emit(event.relation)  # type: ignore
+
+    def _handle_upgrade_or_leader(self, event):
+        """On upgrade/leadership change: ensure we publish the data we have."""
+        self._publish_auto_data()
+
+    def is_ready(self):
+        """The Requirer is ready if the Provider has sent valid data."""
+        try:
+            return bool(self._get_url_from_relation_data())
+        except DataValidationError as e:
+            log.debug("Requirer not ready; validation error encountered: %s" % str(e))
+            return False
+
+    def _publish_auto_data(self):
+        if self._auto_data:
+            host, ip, port = self._auto_data
+            self.provide_ingress_requirements(host=host, ip=ip, port=port)
+
+    def provide_ingress_requirements(
+        self,
+        *,
+        scheme: Optional[str] = None,
+        host: Optional[str] = None,
+        ip: Optional[str] = None,
+        port: int,
+    ):
+        """Publishes the data that Traefik needs to provide ingress.
+
+        Args:
+            scheme: Scheme to be used; if unspecified, use the one used by __init__.
+            host: Hostname to be used by the ingress provider to address the
+             requirer unit; if unspecified, FQDN will be used instead
+            ip: Alternative addressing method other than host to be used by the ingress provider.
+                if unspecified, binding address from juju network API will be used.
+            port: the port of the service (required)
+        """
+        for relation in self.relations:
+            self._provide_ingress_requirements(scheme, host, ip, port, relation)
+
+    def _provide_ingress_requirements(
+        self,
+        scheme: Optional[str],
+        host: Optional[str],
+        ip: Optional[str],
+        port: int,
+        relation: Relation,
+    ):
+        if self.unit.is_leader():
+            self._publish_app_data(scheme, port, relation)
+
+        self._publish_unit_data(host, ip, relation)
+
+    def _publish_unit_data(
+        self,
+        host: Optional[str],
+        ip: Optional[str],
+        relation: Relation,
+    ):
+        if not host:
+            host = socket.getfqdn()
+
+        if ip is None:
+            network_binding = self.charm.model.get_binding(relation)
+            if (
+                network_binding is not None
+                and (bind_address := network_binding.network.bind_address) is not None
+            ):
+                ip = str(bind_address)
+            else:
+                log.error("failed to retrieve ip information from juju")
+
+        unit_databag = relation.data[self.unit]
+        try:
+            IngressRequirerUnitData(host=host, ip=ip).dump(unit_databag)
+        except pydantic.ValidationError as e:
+            msg = "failed to validate unit data"
+            log.info(msg, exc_info=True)  # log to INFO because this might be expected
+            raise DataValidationError(msg) from e
+
+    def _publish_app_data(
+        self,
+        scheme: Optional[str],
+        port: int,
+        relation: Relation,
+    ):
+        # assumes leadership!
+        app_databag = relation.data[self.app]
+
+        if not scheme:
+            # If scheme was not provided, use the one given to the constructor.
+            scheme = self._get_scheme()
+
+        try:
+            IngressRequirerAppData(  # type: ignore  # pyright does not like aliases
+                model=self.model.name,
+                name=self.app.name,
+                scheme=scheme,
+                port=port,
+                strip_prefix=self._strip_prefix,  # type: ignore  # pyright does not like aliases
+                redirect_https=self._redirect_https,  # type: ignore  # pyright does not like aliases
+                healthcheck_params=(
+                    IngressHealthCheck(**self.healthcheck_params)
+                    if self.healthcheck_params
+                    else None
+                ),
+            ).dump(app_databag)
+        except pydantic.ValidationError as e:
+            msg = "failed to validate app data"
+            log.info(msg, exc_info=True)  # log to INFO because this might be expected
+            raise DataValidationError(msg) from e
+
+    @property
+    def relation(self):
+        """The established Relation instance, or None."""
+        return self.relations[0] if self.relations else None
+
+    def _get_url_from_relation_data(self) -> Optional[str]:
+        """The full ingress URL to reach the current unit.
+
+        Returns None if the URL isn't available yet.
+        """
+        relation = self.relation
+        if not relation or not relation.app:
+            return None
+
+        # fetch the provider's app databag
+        try:
+            databag = relation.data[relation.app]
+        except ModelError as e:
+            log.debug(
+                f"Error {e} attempting to read remote app data; "
+                f"probably we are in a relation_departed hook"
+            )
+            return None
+
+        if not databag:  # not ready yet
+            return None
+
+        ingress = IngressProviderAppData.load(databag).ingress
+        if ingress is None:
+            return None
+
+        return str(ingress.url)
+
+    @property
+    def url(self) -> Optional[str]:
+        """The full ingress URL to reach the current unit.
+
+        Returns None if the URL isn't available yet.
+        """
+        data = (
+            typing.cast(Optional[str], self._stored.current_url)  # type: ignore
+            or self._get_url_from_relation_data()
+        )
+        return data

--- a/coordinator/src/nginx_config.py
+++ b/coordinator/src/nginx_config.py
@@ -1,0 +1,74 @@
+# Copyright 2023 Canonical
+# See LICENSE file for licensing details.
+"""Nginx workload."""
+
+import logging
+from typing import Dict, List
+
+from coordinated_workers.nginx import (
+    CA_CERT_PATH,
+    CERT_PATH,
+    KEY_PATH,
+    NginxLocationConfig,
+    NginxUpstream,
+)
+from ops import Container
+
+from pyroscope_config import PyroscopeRole
+
+logger = logging.getLogger(__name__)
+
+
+
+class NginxHelper:
+    """Helper class to generate the nginx configuration."""
+    _pyroscope_port = 4040
+    _nginx_port = 8080
+    _nginx_tls_port = 443
+
+    _locations_write: List[NginxLocationConfig] = [
+        NginxLocationConfig(path="/ingest", backend="ingester",modifier="="),
+    ]
+
+    _locations_query_frontend: List[NginxLocationConfig] = [
+        NginxLocationConfig(path="/pyroscope/render", backend="query-frontend",modifier="="), # API queries
+        NginxLocationConfig(path="/pyroscope/render-diff", backend="query-frontend", modifier="="),  # API queries
+        NginxLocationConfig(path="/querier.v1.QuerierService", backend="query-frontend"),  # called by the frontend
+    ]
+
+    _locations_worker: List[NginxLocationConfig] = [
+        NginxLocationConfig(path="/", backend="worker", modifier="="), # pyroscope UI - not bound to a specific role
+        NginxLocationConfig(path="/assets", backend="worker")
+    ]
+
+    def __init__(
+        self,
+        container: Container,
+    ):
+        self._container = container
+
+    def upstreams(self) -> List[NginxUpstream]:
+        """Generate the list of Nginx upstream metadata configurations."""
+        upstreams = [NginxUpstream(role, self._pyroscope_port, role) for role in PyroscopeRole]
+        # add a generic `worker` upstream that routes to all workers
+        upstreams.append(NginxUpstream("worker", self._pyroscope_port, "worker", ignore_worker_role=True))
+        return upstreams
+
+    def server_ports_to_locations(self) -> Dict[int, List[NginxLocationConfig]]:
+        """Generate a mapping from server ports to a list of Nginx location configurations."""
+        return {
+            self._nginx_tls_port if self._tls_available else self._nginx_port: self._locations_write + self._locations_query_frontend + self._locations_worker
+        }
+
+    @property
+    def _tls_available(self) -> bool:
+        return (
+                self._container.can_connect()
+                and self._container.exists(CERT_PATH)
+                and self._container.exists(KEY_PATH)
+                and self._container.exists(CA_CERT_PATH)
+            )
+
+
+
+

--- a/coordinator/src/pyroscope.py
+++ b/coordinator/src/pyroscope.py
@@ -6,6 +6,7 @@
 
 from typing import Dict, Optional, Set, Tuple
 from coordinated_workers.coordinator import Coordinator
+from urllib.parse import urlparse
 import yaml
 import pyroscope_config
 
@@ -25,7 +26,9 @@ class Pyroscope:
         """Generate the Pyroscope configuration."""
         addrs = coordinator.cluster.gather_addresses()
         addrs_by_role = coordinator.cluster.gather_addresses_by_role()
+        external_url = coordinator._external_url
         config = pyroscope_config.PyroscopeConfig(
+            api=self._build_api_config(external_url),
             server= self._build_server_config(),
             distributor=self._build_distributor_config(),
             ingester=self._build_ingester_config(addrs_by_role),
@@ -95,3 +98,15 @@ class Pyroscope:
                     )
                 )
             )
+
+    def _build_api_config(self, external_url):
+        if external_url:
+            base_url = self._base_url(external_url)
+            if base_url == "" or base_url == "/":
+                # we're behind ingress, but on a root path
+                return pyroscope_config.Api()
+            return pyroscope_config.Api(base_url=base_url)
+        return pyroscope_config.Api()
+
+    def _base_url(self, external_url):
+        return urlparse(external_url).path

--- a/coordinator/src/pyroscope_config.py
+++ b/coordinator/src/pyroscope_config.py
@@ -6,7 +6,7 @@
 from enum import StrEnum, unique
 from typing import List, Optional
 from coordinated_workers.coordinator import ClusterRolesConfig
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 @unique
 class PyroscopeRole(StrEnum):
@@ -104,6 +104,14 @@ class ShardingRingCompactor(BaseModel):
     """Compactor ShardingRing schema."""
     kvstore: Kvstore
 
+class Api(BaseModel):
+    """Api schema."""
+    base_url: Optional[str] = Field(alias='base-url', default=None) # this is the only field with dash in the entire config
+
+    model_config = {
+        'populate_by_name': True
+    }
+
 class Server(BaseModel):
     """Server schema."""
     http_listen_port: int
@@ -150,6 +158,7 @@ class DB(BaseModel):
 
 class PyroscopeConfig(BaseModel):
     """PyroscopeConfig config schema."""
+    api: Api
     server: Server
     distributor: Distributor
     ingester: Ingester

--- a/coordinator/tests/unit/conftest.py
+++ b/coordinator/tests/unit/conftest.py
@@ -42,6 +42,32 @@ def s3(s3_config):
     )
 
 @pytest.fixture(scope="function")
+def ingress_subpath():
+    return Relation(
+        "ingress",
+        remote_app_data={"ingress": json.dumps({
+            "url": "http://1.2.3.5/model-pyroscope-k8s"
+        })},
+        local_unit_data={
+            "host": "localhost",
+            "ip": "127.0.0.1",
+        }
+    )
+
+@pytest.fixture(scope="function")
+def ingress_subdomain():
+    return Relation(
+        "ingress",
+        remote_app_data={"ingress": json.dumps({
+            "url": "http://pyroscope-k8s.canonical.com"
+        })},
+        local_unit_data={
+            "host": "localhost",
+            "ip": "127.0.0.1",
+        }
+    )
+
+@pytest.fixture(scope="function")
 def all_worker():
     return Relation(
         "pyroscope-cluster",

--- a/coordinator/tests/unit/test_charm.py
+++ b/coordinator/tests/unit/test_charm.py
@@ -5,8 +5,8 @@ from ops.testing import State
 
 
 @pytest.fixture(params=(True, False))
-def base_state(request, s3):
-    return State(leader=request.param, relations=[s3])
+def base_state(request, s3, nginx_container, nginx_prometheus_exporter_container):
+    return State(leader=request.param, relations=[s3], containers=[nginx_container, nginx_prometheus_exporter_container],)
 
 
 def test_smoke(context, base_state):

--- a/coordinator/tests/unit/test_charm_statuses.py
+++ b/coordinator/tests/unit/test_charm_statuses.py
@@ -1,26 +1,31 @@
 import ops
 from ops.testing import PeerRelation, State
 
-def test_monolithic_status_no_s3_no_workers(context):
-    state_out = context.run(context.on.start(), State(unit_status=ops.ActiveStatus(), leader=True))
+def test_monolithic_status_no_s3_no_workers(context, nginx_container, nginx_prometheus_exporter_container):
+    state_out = context.run(
+        context.on.start(),
+        State(unit_status=ops.ActiveStatus(), containers=[nginx_container, nginx_prometheus_exporter_container], leader=True)
+    )
     assert state_out.unit_status.name == "blocked"
 
-def test_scaled_status_no_s3(context):
+def test_scaled_status_no_s3(context, nginx_container, nginx_prometheus_exporter_container):
     state_out = context.run(
         context.on.start(),
         State(
             relations=[PeerRelation("peers", peers_data={1: {}, 2: {}})],
+            containers=[nginx_container, nginx_prometheus_exporter_container],
             unit_status=ops.ActiveStatus(),
         ),
     )
     assert state_out.unit_status.name == "blocked"
 
 
-def test_scaled_status_no_workers(context):
+def test_scaled_status_no_workers(context, nginx_container, nginx_prometheus_exporter_container):
     state_out = context.run(
         context.on.start(),
         State(
             relations=[PeerRelation("peers", peers_data={1: {}, 2: {}})],
+            containers=[nginx_container, nginx_prometheus_exporter_container],
             unit_status=ops.ActiveStatus(),
         ),
     )

--- a/coordinator/tests/unit/test_nginx_config.py
+++ b/coordinator/tests/unit/test_nginx_config.py
@@ -1,0 +1,62 @@
+from contextlib import contextmanager
+from unittest.mock import MagicMock, PropertyMock, patch
+
+import pytest
+from coordinated_workers.nginx import NginxConfig
+
+from nginx_config import (
+    NginxHelper,
+)
+
+
+@contextmanager
+def mock_ipv6(enable: bool):
+    with patch("coordinated_workers.nginx.is_ipv6_enabled", MagicMock(return_value=enable)):
+        yield
+
+
+@pytest.fixture(scope="module")
+def nginx_config():
+    def _nginx_config(tls=False, ipv6=True):
+        with mock_ipv6(ipv6):
+            with patch.object(NginxHelper, "_tls_available", new=PropertyMock(return_value=tls)):
+                nginx_helper = NginxHelper(MagicMock())
+                return NginxConfig(server_name="localhost",
+                                    upstream_configs=nginx_helper.upstreams(),
+                                    server_ports_to_locations=nginx_helper.server_ports_to_locations())
+    return _nginx_config
+
+
+@pytest.mark.parametrize(
+    "addresses_by_role",
+    [
+        ({"ingester": ["address.one"]}),
+        ({"ingester": ["address.one", "address.two"]}),
+        ({"ingester": ["address.one", "address.two", "address.three"]}),
+    ],
+)
+def test_upstreams_config(nginx_config, addresses_by_role):
+    upstreams_config = nginx_config(tls=False).get_config(addresses_by_role, False)
+    # assert read upstream block
+    addresses = [address for address_list in addresses_by_role.values() for address in address_list]
+    for role in addresses_by_role.keys():
+        assert f"upstream {role}" in upstreams_config
+    for addr in addresses:
+        assert f"server {addr}:{4040}" in upstreams_config
+    for addr in addresses:
+        assert f"server {addr}:{4040}" in upstreams_config
+
+@pytest.mark.parametrize("tls", (True, False))
+@pytest.mark.parametrize("ipv6", (True, False))
+def test_servers_config(ipv6, tls, nginx_config):
+
+    server_config = nginx_config(tls=tls, ipv6=ipv6).get_config(
+        {"ingester": ["address.one"]}, tls
+    )
+    ipv4_args = "443 ssl" if tls else f"{8080}"
+    assert f"listen {ipv4_args}" in  server_config
+    ipv6_args = "[::]:443 ssl" if tls else f"[::]:{8080}"
+    if ipv6:
+        assert f"listen {ipv6_args}" in server_config
+    else:
+        assert f"listen {ipv6_args}" not in server_config

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -20,6 +20,7 @@ MINIO_APP = "minio"
 S3_APP = "s3-integrator"
 WORKER_APP = "pyroscope-worker"
 PYROSCOPE_APP = "pyroscope"
+TRAEFIK_APP = "trfk"
 
 logger = logging.getLogger(__name__)
 
@@ -135,3 +136,14 @@ def _deploy_and_configure_minio(juju: Juju):
     })
     task = juju.run(S3_APP + "/0", "sync-s3-credentials", params=keys)
     assert task.status == "completed"
+
+def get_ingress_proxied_hostname(juju: Juju):
+    status = juju.status()
+    status_msg = status.apps[TRAEFIK_APP].app_status.message
+
+    # hacky way to get ingress hostname, but it's the safest one.
+    if "Serving at" not in status_msg:
+        raise RuntimeError(
+            f"Ingressed hostname is not present in {TRAEFIK_APP} status message."
+        )
+    return status_msg.replace("Serving at", "").strip()

--- a/tests/integration/test_ingress.py
+++ b/tests/integration/test_ingress.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import logging
+from pathlib import Path
+
+import jubilant
+import pytest
+from jubilant import Juju
+
+from helpers import (
+    PYROSCOPE_APP,
+    WORKER_APP,
+    deploy_monolithic_cluster,
+    TRAEFIK_APP,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.mark.setup
+def test_build_and_deploy(juju: Juju):
+    # GIVEN an empty model
+    # WHEN deploying the tempo cluster and traefik
+    juju.deploy("traefik-k8s", app=TRAEFIK_APP, channel="edge", trust=True)
+    deploy_monolithic_cluster(juju)
+
+    # THEN the s3-integrator, coordinator, worker, and traefik are all in active/idle state
+    juju.wait(
+        lambda status: jubilant.all_active(status, TRAEFIK_APP, PYROSCOPE_APP, WORKER_APP),
+        error=jubilant.any_error,
+        timeout=2000,
+    )
+
+
+def test_relate_ingress(juju: Juju):
+    # GIVEN a model with a tempo cluster and traefik
+    # WHEN we integrate the tempo cluster with traefik over ingress
+    juju.integrate(PYROSCOPE_APP + ":ingress", TRAEFIK_APP + ":ingress")
+
+    # THEN the coordinator, worker, and traefik are all in active/idle state
+    juju.wait(
+        lambda status: jubilant.all_active(status, TRAEFIK_APP, PYROSCOPE_APP, WORKER_APP),
+        error=jubilant.any_error,
+        timeout=2000,
+    )
+
+
+
+
+@pytest.mark.teardown
+def test_remove_ingress(juju: Juju):
+    # GIVEN a model with traefik and the tempo cluster integrated
+    # WHEN we remove the ingress relation
+    juju.remove_relation(PYROSCOPE_APP + ":ingress", TRAEFIK_APP + ":ingress")
+
+    # THEN the coordinator and worker are in active/idle state
+    juju.wait(
+        lambda status: jubilant.all_active(status, PYROSCOPE_APP, WORKER_APP),
+        error=jubilant.any_error,
+        timeout=2000,
+    )
+
+
+@pytest.mark.teardown
+def test_teardown(juju: Juju):
+    # GIVEN a model with traefik and the tempo cluster
+    # WHEN we remove traefik, the coordinator, and the worker
+    juju.remove_application(PYROSCOPE_APP)
+    juju.remove_application(WORKER_APP)
+    juju.remove_application(TRAEFIK_APP)
+
+    # THEN nothing throws an exception


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
Pyroscope charm didn't have a working nginx config.

## Solution
<!-- A summary of the solution addressing the above issue -->
Add nginx config and an ingress object. Fixes #8 

## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->
Deploy the following bundle:
```
bundle: kubernetes
applications:
  minio:
    charm: minio
    channel: ckf-1.10/edge
    revision: 459
    base: ubuntu@20.04/stable
    resources:
      oci-image: 547
    scale: 1
    options:
      access-key: accesskey
      secret-key: secretkey
    constraints: arch=amd64
    storage:
      minio-data: kubernetes,1,10240M
    trust: true
  pyroscope-coordinator-k8s:
    charm: local:pyroscope-coordinator-k8s-15
    scale: 1
    constraints: arch=amd64
  pyroscope-worker-k8s:
    charm: pyroscope-worker-k8s
    channel: 2/edge
    revision: 1
    resources:
      pyroscope-image: 1
    scale: 1
    constraints: arch=amd64
    storage:
      data: kubernetes,1,1024M
    trust: true
  s3:
    charm: s3-integrator
    channel: latest/edge
    revision: 155
    base: ubuntu@22.04/stable
    scale: 1
    options:
      bucket: pyroscope
      endpoint: minio-0.minio-endpoints.test-pyroscope.svc.cluster.local:9000
    constraints: arch=amd64
    trust: true
  traefik-k8s:
    charm: traefik-k8s
    channel: latest/stable
    revision: 236
    base: ubuntu@20.04/stable
    resources:
      traefik-image: 161
    scale: 1
    constraints: arch=amd64
    storage:
      configurations: kubernetes,1,1024M
    trust: true
relations:
- - pyroscope-coordinator-k8s:pyroscope-cluster
  - pyroscope-worker-k8s:pyroscope-cluster
- - s3:s3-credentials
  - pyroscope-coordinator-k8s:s3
- - traefik-k8s:ingress
  - pyroscope-coordinator-k8s:ingress
```

Verify that pyroscope UI is accessible on the traefik-provided URL:
![Screenshot from 2025-06-06 13-24-32](https://github.com/user-attachments/assets/da001ef7-bb55-46d9-89b9-5d60d05cd94e)

Known issues: #36 - tag explorer view errors out with a 404. Similarly, "Admin" link in the sidebar nav doesn't contain the ingressed path.


## Upgrade Notes
<!-- To upgrade from an older revision of charmed pyroscope, ... -->
