### PR TITLE
Update documentation references for the coordinator and worker

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
 # pyroscope-k8s-operator
 This charmed operator is part of automating the operational procedures of running Grafana Pyroscope, an open-source profiling backend, in microservices mode.
 
+This repository hosts two charms following the [coordinated-workers](https://discourse.charmhub.io/t/cos-lite-docs-managing-deployments-of-cos-lite-ha-addons/15213) pattern.
+Together, they deploy and operate Grafana Pyroscope, an open-source profiling backend by Grafana Labs. See [charmed Pyroscope HA](https://discourse.charmhub.io/t/18120) documentation for more details.
+ 
+The charm in `./coordinator` deploys and operates a configurator charm and an nginx instance responsible for routing traffic to the worker nodes.
+
+The charm in `./worker` deploys and operates one or multiple roles of Pyroscope's distributed architecture.

--- a/coordinator/README.md
+++ b/coordinator/README.md
@@ -4,7 +4,7 @@
 [![Release](https://github.com/canonical/pyroscope-k8s-operator/actions/workflows/release.yaml/badge.svg)](https://github.com/canonical/pyroscope-k8s-operator/actions/workflows/release.yaml)
 [![Discourse Status](https://img.shields.io/discourse/status?server=https%3A%2F%2Fdiscourse.charmhub.io&style=flat&label=CharmHub%20Discourse)](https://discourse.charmhub.io)
 
-This repository contains the source code for a Charmed Operator that drives [Pyroscope] on Kubernetes. It is destined to work together with [pyroscope-worker-k8s](https://charmhub.io/pyroscope-worker-k8s) to deploy and operate Pyroscope, a distributed profiling backend backed by Grafana.
+This repository contains the source code for a Charmed Operator that drives [Pyroscope] on Kubernetes. It is destined to work together with [pyroscope-worker-k8s](https://charmhub.io/pyroscope-worker-k8s) to deploy and operate Grafana Pyroscope, a distributed profiling backend backed by Grafana. See [charmed Pyroscope HA](https://discourse.charmhub.io/t/18120) documentation for more details.
 
 ## Usage
 

--- a/coordinator/charmcraft.yaml
+++ b/coordinator/charmcraft.yaml
@@ -30,7 +30,7 @@ resources:
     upstream-source: nginx/nginx-prometheus-exporter:1.1.0
 
 links:
-  documentation: https://discourse.charmhub.io/t/pyroscope-coordinator-k8s-docs-index/15419
+  documentation: https://discourse.charmhub.io/t/18121
   website: https://charmhub.io/pyroscope-coordinator-k8s
   source: https://github.com/canonical/pyroscope-k8s-operator/tree/main/coordinator
   issues: https://github.com/canonical/pyroscope-k8s-operator/issues

--- a/worker/README.md
+++ b/worker/README.md
@@ -4,7 +4,7 @@
 [![Release](https://github.com/canonical/pyroscope-k8s-operator/actions/workflows/release.yaml/badge.svg)](https://github.com/canonical/pyroscope-k8s-operator/actions/workflows/release.yaml)
 [![Discourse Status](https://img.shields.io/discourse/status?server=https%3A%2F%2Fdiscourse.charmhub.io&style=flat&label=CharmHub%20Discourse)](https://discourse.charmhub.io)
 
-This repository contains the source code for a Charmed Operator that drives [Pyroscope] on Kubernetes. It is destined to work together with [pyroscope-worker-k8s](https://charmhub.io/pyroscope-worker-k8s) to deploy and operate Pyroscope, a distributed profiling backend backed by Grafana.
+This repository contains the source code for a Charmed Operator that drives [Pyroscope] on Kubernetes. It is destined to work together with [pyroscope-coordinator-k8s](https://charmhub.io/pyroscope-coordinator-k8s) to deploy and operate Grafana Pyroscope, a distributed profiling backend backed by Grafana. See [charmed Pyroscope HA](https://discourse.charmhub.io/t/18120) documentation for more details.
 
 ## Usage
 

--- a/worker/charmcraft.yaml
+++ b/worker/charmcraft.yaml
@@ -29,7 +29,7 @@ resources:
     upstream-source: grafana/pyroscope:1.13.4
 
 links:
-  documentation: https://discourse.charmhub.io/t/pyroscope-worker-k8s-docs-index/15419
+  documentation: https://discourse.charmhub.io/t/18122
   website: https://charmhub.io/pyroscope-worker-k8s
   source: https://github.com/canonical/pyroscope-k8s-operator/tree/main/worker
   issues: https://github.com/canonical/pyroscope-k8s-operator/issues


### PR DESCRIPTION
- Fix the links in `charmcraft.yaml` to point to Pyroscope's coordinator and worker documentation. 
- Add a link to the solution-level documentation in the README files



