### PR TITLE
Add Pyroscope to Catalogue

### DIFF
--- a/coordinator/src/charm.py
+++ b/coordinator/src/charm.py
@@ -172,7 +172,8 @@ class PyroscopeCoordinatorCharm(CharmBase):
             icon="flame",
             url=self._most_external_url,
             description=(
-                "Grafana Pyroscope is a distributed continuous profiling backend by Grafana Labs."
+                "Grafana Pyroscope is a distributed continuous profiling backend. "
+                "Allows you to collect, store, query, and visualize profiles from your distributed deployment."
             ),
         )
 

--- a/coordinator/src/charm.py
+++ b/coordinator/src/charm.py
@@ -8,6 +8,7 @@ import logging
 import socket
 from typing import Optional, Set, Tuple
 from urllib.parse import urlparse
+from charms.catalogue_k8s.v1.catalogue import CatalogueItem
 
 from charms.traefik_k8s.v2.ingress import IngressPerAppRequirer
 from coordinated_workers.coordinator import Coordinator
@@ -70,8 +71,7 @@ class PyroscopeCoordinatorCharm(CharmBase):
             workload_tracing_protocols=["jaeger_thrift_http"],
             container_name="charm",
             resources_requests=lambda _: {"cpu": "50m", "memory": "100Mi"},
-            # FIXME: add the rest of the optional config
-            # catalogue_item
+            catalogue_item=self._catalogue_item,
         )
 
         # do this regardless of what event we are processing
@@ -152,6 +152,19 @@ class PyroscopeCoordinatorCharm(CharmBase):
             and self._nginx_container.exists(CERT_PATH)
             and self._nginx_container.exists(KEY_PATH)
             and self._nginx_container.exists(CA_CERT_PATH)
+        )
+
+    @property
+    def _catalogue_item(self) -> CatalogueItem:
+        """A catalogue application entry for this Pyroscope instance."""
+        return CatalogueItem(
+            # use app name in case there are multiple Pyroscope apps deployed.
+            name=self.app.name,
+            icon="flame",
+            url=self._most_external_url,
+            description=(
+                "Grafana Pyroscope is a distributed continuous profiling backend by Grafana Labs."
+            ),
         )
 
     ##################

--- a/coordinator/src/charm.py
+++ b/coordinator/src/charm.py
@@ -168,7 +168,7 @@ class PyroscopeCoordinatorCharm(CharmBase):
         """A catalogue application entry for this Pyroscope instance."""
         return CatalogueItem(
             # use app name in case there are multiple Pyroscope apps deployed.
-            name=self.app.name,
+            name=f"Pyroscope ({self.app.name})",
             icon="flame",
             url=self._most_external_url,
             description=(

--- a/coordinator/src/nginx_config.py
+++ b/coordinator/src/nginx_config.py
@@ -15,8 +15,8 @@ from pyroscope_config import PyroscopeRole
 logger = logging.getLogger(__name__)
 
 
-_nginx_port = 8080
-_nginx_tls_port = 443
+nginx_port = 8080
+nginx_tls_port = 443
 
 _locations_write: List[NginxLocationConfig] = [
     NginxLocationConfig(path="/ingest", backend="ingester", modifier="="),
@@ -65,7 +65,7 @@ def server_ports_to_locations(
 ) -> Dict[int, List[NginxLocationConfig]]:
     """Generate a mapping from server ports to a list of Nginx location configurations."""
     return {
-        _nginx_tls_port if tls_available else _nginx_port: _locations_write
+        nginx_tls_port if tls_available else nginx_port: _locations_write
         + _locations_query_frontend
         + _locations_tenant_settings
         + _locations_ad_hoc_profiles

--- a/coordinator/tests/unit/test_nginx_config.py
+++ b/coordinator/tests/unit/test_nginx_config.py
@@ -32,13 +32,13 @@ def test_servers_config(tls):
 
     # THEN the locations are mapped to the right port
     assert server_ports_to_locations[
-        nginx_config._nginx_tls_port if tls else nginx_config._nginx_port
+        nginx_config.nginx_tls_port if tls else nginx_config.nginx_port
     ]
 
     # AND THEN the other port isn't in the configuration
     assert (
         server_ports_to_locations.get(
-            nginx_config._nginx_port if tls else nginx_config._nginx_tls_port
+            nginx_config.nginx_port if tls else nginx_config.nginx_tls_port
         )
         is None
     )

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -29,6 +29,7 @@ S3_CREDENTIALS = {
     "access-key": ACCESS_KEY,
     "secret-key": SECRET_KEY,
 }
+INTEGRATION_TESTERS_CHANNEL = "2/edge"
 
 logger = logging.getLogger(__name__)
 

--- a/tests/integration/test_core_cos_integrations.py
+++ b/tests/integration/test_core_cos_integrations.py
@@ -11,8 +11,6 @@ from jubilant import Juju, all_active, any_error
 from tenacity import (
     retry,
     stop_after_attempt,
-    stop_after_delay,
-    wait_exponential,
     wait_fixed,
 )
 
@@ -190,7 +188,7 @@ def test_teardown(juju: Juju):
         lambda status: all_active(status, PYROSCOPE_APP, *ALL_WORKERS),
         error=any_error,
         timeout=2000,
-        delay=5,
+        delay=10,
         successes=3,
     )
 


### PR DESCRIPTION
Fixes #5 

## Testing Instructions
1. Deploy Pyroscope cluster with this coordinator
2. `juju deploy catalogue-k8s catalogue --trust`
3. `juju deploy traefik-k8s traefik --channel edge --trust`
4. `juju integrate pyroscope traefik `
5. `juju integrate pyroscope catalogue`
6. Open Catalogue UI
![image](https://github.com/user-attachments/assets/1b37ed74-1875-4a50-8136-36c23f07c918)
7. Clicking on the pyroscope entry should redirect you to the Pyroscope UI
![image](https://github.com/user-attachments/assets/f0b0360d-cc6b-4402-8c70-0a45f7912459)
