### PR TITLE
Add resources requests & limits

### DIFF
--- a/coordinator/charmcraft.yaml
+++ b/coordinator/charmcraft.yaml
@@ -118,3 +118,17 @@ parts:
     # FIXME: override-build with "git describe --always > $CRAFT_PART_INSTALL/version" causes
     # charm pack to fail "fatal: not a git repository (or any of the parent directories): .git"
 
+config:
+  options:
+    cpu_limit:
+      description: |
+        K8s cpu resource limit, e.g. "1" or "500m". Default is unset (no limit). This value is used
+        for the "limits" portion of the resource requirements.
+        See https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+      type: string
+    memory_limit:
+      description: |
+        K8s memory resource limit, e.g. "1Gi". Default is unset (no limit). This value is used
+        for the "limits" portion of the resource requirements.
+        See https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+      type: string

--- a/coordinator/src/charm.py
+++ b/coordinator/src/charm.py
@@ -68,8 +68,9 @@ class PyroscopeCoordinatorCharm(CharmBase):
             workers_config=self.pyroscope.config,
             worker_ports=self._get_worker_ports,
             workload_tracing_protocols=["jaeger_thrift_http"],
+            container_name="charm",
+            resources_requests=lambda _: {"cpu": "50m", "memory": "100Mi"},
             # FIXME: add the rest of the optional config
-            # resources_requests, resources_limit_options, container_name
             # catalogue_item
         )
 

--- a/worker/charmcraft.yaml
+++ b/worker/charmcraft.yaml
@@ -151,3 +151,16 @@ config:
 
         Note that for a pyroscope deployment as a whole to be consistent, each role needs to be assigned to at least one worker node. If this condition
         is not met, the coordinator charm will set blocked status and the deployment will shut down.
+
+    cpu_limit:
+      description: |
+        K8s cpu resource limit, e.g. "1" or "500m". Default is unset (no limit). This value is used
+        for the "limits" portion of the resource requirements.
+        See https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+      type: string
+    memory_limit:
+      description: |
+        K8s memory resource limit, e.g. "1Gi". Default is unset (no limit). This value is used
+        for the "limits" portion of the resource requirements.
+        See https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+      type: string

--- a/worker/tests/unit/test_charm_statuses.py
+++ b/worker/tests/unit/test_charm_statuses.py
@@ -1,0 +1,48 @@
+import json
+import ops
+from ops.testing import State, Relation
+from tests.unit.conftest import config_on_disk, endpoint_ready, k8s_patch
+
+
+@k8s_patch(status=ops.BlockedStatus("`juju trust` this application"))
+@config_on_disk()
+@endpoint_ready()
+def test_patch_k8s_failed(ctx, pyroscope_container):
+    state_out = ctx.run(
+        ctx.on.config_changed(),
+        state=State(
+            containers=[pyroscope_container],
+            relations=[
+                Relation(
+                    "pyroscope-cluster",
+                    remote_app_data={
+                        "worker_config": json.dumps("beef"),
+                    },
+                )
+            ],
+        ),
+    )
+
+    assert state_out.unit_status == ops.BlockedStatus("`juju trust` this application")
+
+
+@k8s_patch(status=ops.WaitingStatus(""))
+@config_on_disk()
+@endpoint_ready()
+def test_patch_k8s_waiting(ctx, pyroscope_container):
+    state_out = ctx.run(
+        ctx.on.config_changed(),
+        state=State(
+            containers=[pyroscope_container],
+            relations=[
+                Relation(
+                    "pyroscope-cluster",
+                    remote_app_data={
+                        "worker_config": json.dumps("beef"),
+                    },
+                )
+            ],
+        ),
+    )
+
+    assert state_out.unit_status == ops.WaitingStatus("")

--- a/worker/tests/unit/test_pebble_plan.py
+++ b/worker/tests/unit/test_pebble_plan.py
@@ -105,7 +105,7 @@ def test_tracing_config_in_pebble_plan(ctx, pyroscope_container):
             "ready": {
                 "http": {"url": f"http://{host}:4040/ready"},
                 "override": "replace",
-                "threshold": 3
+                "threshold": 3,
             }
         },
         "services": {
@@ -115,12 +115,14 @@ def test_tracing_config_in_pebble_plan(ctx, pyroscope_container):
                 "command": "/usr/bin/pyroscope -config.file=/etc/worker/config.yaml -target=all",
                 "startup": "enabled",
                 "environment": {
-                    "JAEGER_ENDPOINT": (f"{tempo_endpoint}/api/traces?format=jaeger.thrift"),
+                    "JAEGER_ENDPOINT": (
+                        f"{tempo_endpoint}/api/traces?format=jaeger.thrift"
+                    ),
                     "JAEGER_SAMPLER_PARAM": "1",
                     "JAEGER_SAMPLER_TYPE": "const",
                     "JAEGER_TAGS": "juju_application=worker,juju_model=test"
                     + ",juju_model_uuid=00000000-0000-4000-8000-000000000000,juju_unit=worker/0,juju_charm=pyroscope",
-                }
+                },
             }
         },
     }
@@ -133,9 +135,9 @@ def test_tracing_config_in_pebble_plan(ctx, pyroscope_container):
                 "pyroscope-cluster",
                 remote_app_data={
                     "worker_config": json.dumps("beef"),
-                    "workload_tracing_receivers": json.dumps({
-                        "jaeger_thrift_http": tempo_endpoint
-                    })
+                    "workload_tracing_receivers": json.dumps(
+                        {"jaeger_thrift_http": tempo_endpoint}
+                    ),
                 },
             ),
         ],
@@ -144,10 +146,7 @@ def test_tracing_config_in_pebble_plan(ctx, pyroscope_container):
         },
     )
     # WHEN a workload pebble ready event is fired
-    state_out = ctx.run(
-        ctx.on.pebble_ready(pyroscope_container),
-        state= state
-    )
+    state_out = ctx.run(ctx.on.pebble_ready(pyroscope_container), state=state)
 
     # THEN the pebble plan contains the workload tracing-related environment variables
     pyroscope_container_out = state_out.get_container(pyroscope_container.name)


### PR DESCRIPTION
Fixes #7 
For the coordinator and worker:
- Set minimal requests just to ensure scheduling.
- Add `cpu` and `memory` limits as config options.

## Testing Instructions
1. Deploy the pyroscope coordinator and worker without `--trust`
2. coordinator and worker will be set to `blocked`
3. `juju trust coordinator` and `juju trust worker`
4. coordinator and worker will be set to `active`