### PR TITLE
feat: add some metric-based alert rules

### DIFF
--- a/coordinator/src/nginx_config.py
+++ b/coordinator/src/nginx_config.py
@@ -19,7 +19,7 @@ nginx_port = 8080
 nginx_tls_port = 443
 
 _locations_write: List[NginxLocationConfig] = [
-    NginxLocationConfig(path="/ingest", backend="ingester", modifier="="),
+    NginxLocationConfig(path="/ingest", backend="distributor", modifier="="),
 ]
 
 _locations_query_frontend: List[NginxLocationConfig] = [
@@ -39,7 +39,9 @@ _locations_tenant_settings: List[NginxLocationConfig] = [
 ]
 
 _locations_ad_hoc_profiles: List[NginxLocationConfig] = [
-    NginxLocationConfig(path="/adhocprofiles.v1.AdHocProfileService", backend="ad-hoc-profiles")
+    NginxLocationConfig(
+        path="/adhocprofiles.v1.AdHocProfileService", backend="ad-hoc-profiles"
+    )
 ]
 
 _locations_worker: List[NginxLocationConfig] = [

--- a/coordinator/src/prometheus_alert_rules/nginx/alerts.yaml
+++ b/coordinator/src/prometheus_alert_rules/nginx/alerts.yaml
@@ -1,0 +1,23 @@
+# Obtained from:
+# https://samber.github.io/awesome-prometheus-alerts/rules#nginx-1
+
+groups:
+- name: NginxExporter
+  rules:
+    - alert: NginxHighHttp4xxErrorRate
+      expr: 'sum(rate(nginx_http_requests_total{status=~"^4.."}[1m])) / sum(rate(nginx_http_requests_total[1m])) * 100 > 5'
+      for: 1m
+      labels:
+        severity: critical
+      annotations:
+        summary: Nginx high HTTP 4xx error rate (instance {{ $labels.instance }})
+        description: "Too many HTTP requests with status 4xx (> 5%)\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
+
+    - alert: NginxHighHttp5xxErrorRate
+      expr: 'sum(rate(nginx_http_requests_total{status=~"^5.."}[1m])) / sum(rate(nginx_http_requests_total[1m])) * 100 > 5'
+      for: 1m
+      labels:
+        severity: critical
+      annotations:
+        summary: Nginx high HTTP 5xx error rate (instance {{ $labels.instance }})
+        description: "Too many HTTP requests with status 5xx (> 5%)\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"

--- a/coordinator/src/prometheus_alert_rules/workers/alerts.yaml
+++ b/coordinator/src/prometheus_alert_rules/workers/alerts.yaml
@@ -1,0 +1,116 @@
+# TODO: revisit the alert rules when https://github.com/grafana/pyroscope/issues/3624 is addressed
+
+groups:
+- name: pyroscope_general_alerts
+  rules:
+  - alert: PyroscopeRingMemberUnhealthy
+    expr:  max by (job, instance)(pyroscope_ring_members{state="Unhealthy"}) > 0
+    for: 5m
+    labels:
+      severity: critical
+    annotations:
+      summary: Ring members unhealthy ({{ $labels.instance }})
+      description: "At least one Pyroscope component is in an Unhealthy state on {{ $labels.instance }}."
+  - alert: PyroscopeStoreGatewayNotSyncing
+    expr: |
+      max by (job, instance) (increase(pyroscope_storegateway_bucket_sync_total[15m])) == 0
+    for: 15m
+    labels:
+      severity: critical
+    annotations:
+      summary: "Store-gateway not syncing ({{ $labels.instance }})"
+      description: No bucket syncs occurred on {{ $labels.instance }} in the last 15 minutes.
+  - alert: PyroscopeTCPConnectionsLimit
+    expr:  max by (job, instance)(100 * (pyroscope_tcp_connections / pyroscope_tcp_connections_limit) >= 80 and pyroscope_tcp_connections_limit > 0)
+    for: 5m
+    labels:
+      severity: warning
+    annotations:
+      summary: "TCP connections nearing limit ({{ $labels.instance }})"
+      description: "Instance {{ $labels.instance }} is using over 80% of its allowed TCP connections."
+  - alert: PyroscopePanicsDetected
+    expr: increase(pyroscope_panic_total[1m]) > 0
+    labels:
+      severity: critical
+    annotations:
+      summary: "Pyroscope panic detected ({{ $labels.instance }})"
+      description: "Instance {{ $labels.instance }} has recorded at least one panic in the last minute."
+  - alert: PyroscopeFrontendNotConnectedToScheduler
+    expr: min by (job, instance)(pyroscope_query_frontend_connected_schedulers) == 0
+    for: 5m
+    labels:
+      severity: warning
+    annotations:
+      summary: "Query frontend not connected to any schedulers ({{ $labels.instance }})"
+      description: "Pyroscope frontend {{ $labels.instance }} is not connected to any schedulers."
+  - alert: PyroscopeCompactorFailures
+    expr: sum by (instance, job)(increase(pyroscope_compactor_runs_failed_total{reason="error"}[5m])) > 0
+    for: 5m
+    labels:
+      severity: warning
+    annotations:
+      summary: "Compactor run failed ({{ $labels.instance }})"
+      description: |
+        One or more compactor runs failed in the last 5 minutes on instance {{ $labels.instance }}.
+  - alert: PyroscopeBlockCleanupFailures
+    expr: sum by (instance, job)(increase(pyroscope_compactor_block_cleanup_failures_total[5m])) > 0
+    for: 5m
+    labels:
+      severity: warning
+    annotations:
+      summary: Compactor block cleanup failures ({{ $labels.instance }})
+      description: >
+        Failures occurred while attempting to clean up compactor blocks on instance {{ $labels.instance }}.
+  - alert: PyroscopeObjectStoreOperationFailures
+    expr: sum by (instance, job, bucket, operation)(increase(objstore_bucket_operation_failures_total[5m])) > 0
+    for: 5m
+    labels:
+      severity: warning
+    annotations:
+      summary: "Object store operation failures detected ({{ $labels.instance }})"
+      description: "Bucket '{{ $labels.bucket }}' operation '{{ $labels.operation }}' has failed {{ $value }} times in the last 5 minutes."
+      
+- name: pyroscope_read_alerts
+  rules:
+  - alert: PyroscopeHighReadRequestLatency
+    expr: |
+      histogram_quantile(0.99, sum by (method, route, le, job, instance) (rate(pyroscope_request_duration_seconds_bucket{route=~"pyroscope_render"}[5m]))) > 1
+    for: 5m
+    labels:
+      severity: warning
+    annotations:
+      summary: "High p99 read requests latency on {{ $labels.method }} {{ $labels.route }}"
+      description: |
+        The 99th percentile read requests duration is over 1s for route {{ $labels.route }} (method {{ $labels.method }}).
+  - alert: PyroscopeReadRequestErrors
+    expr: 100 * sum(rate(pyroscope_request_duration_seconds_count{route=~"pyroscope_render",status_code=~"5.."}[5m])) by (route,method,job,instance) / sum(rate(pyroscope_request_duration_seconds_count{route=~"pyroscope_render"}[5m])) by (route,method,job,instance)  > 10
+    for: 5m
+    labels:
+      severity: warning
+    annotations:
+      summary: High read request errors on {{ $labels.method }} {{ $labels.route }}
+      description: |
+        Instance {{ $labels.instance }} is experiencing {{ printf "%.2f" $value }}% read requests error rate for route {{ $labels.route }} (method {{ $labels.method }}).
+
+- name: pyroscope_write_alerts
+  rules:
+  - alert: PyroscopeHighWriteRequestLatency
+    expr: |
+      histogram_quantile(0.99, sum by (method, route, le, job, instance) (rate(pyroscope_request_duration_seconds_bucket{route=~"ingest|opentelemetry_proto_collector_profiles_v1development_profilesservice_export"}[5m]))) > 1
+    for: 5m
+    labels:
+      severity: warning
+    annotations:
+      summary: "High p99 write requests latency on {{ $labels.method }} {{ $labels.route }}"
+      description: |
+        The 99th percentile write requests duration is over 1s on instance {{ $labels.instance }} for route {{ $labels.route }} (method {{ $labels.method }}).
+  - alert: PyroscopeWriteRequestErrors
+    expr: 100 * sum(rate(pyroscope_request_duration_seconds_count{route=~"ingest|opentelemetry_proto_collector_profiles_v1development_profilesservice_export",status_code=~"5.."}[5m])) by (route,method,job,instance) / sum(rate(pyroscope_request_duration_seconds_count{route=~"ingest|opentelemetry_proto_collector_profiles_v1development_profilesservice_export"}[5m])) by (route,method,job,instance)  > 10
+    for: 5m
+    labels:
+      severity: warning
+    annotations:
+      summary: High write request errors on {{ $labels.method }} {{ $labels.route }}
+      description: |
+        Instance {{ $labels.instance }} is experiencing {{ printf "%.2f" $value }}% write requests error rate for route {{ $labels.route }} (method {{ $labels.method }}).
+

--- a/coordinator/src/prometheus_alert_rules/workers/alerts.yaml
+++ b/coordinator/src/prometheus_alert_rules/workers/alerts.yaml
@@ -44,17 +44,17 @@ groups:
       summary: "Query frontend not connected to any schedulers ({{ $labels.instance }})"
       description: "Pyroscope frontend {{ $labels.instance }} is not connected to any schedulers."
   - alert: PyroscopeCompactorFailures
-    expr: sum by (instance, job)(increase(pyroscope_compactor_runs_failed_total{reason="error"}[5m])) > 0
-    for: 5m
+    expr: sum by (instance, job)(increase(pyroscope_compactor_runs_failed_total{reason="error"}[1h])) > 0
+    for: 1h
     labels:
       severity: warning
     annotations:
       summary: "Compactor run failed ({{ $labels.instance }})"
       description: |
-        One or more compactor runs failed in the last 5 minutes on instance {{ $labels.instance }}.
+        One or more compactor runs failed in the last 1 hour on instance {{ $labels.instance }}.
   - alert: PyroscopeBlockCleanupFailures
-    expr: sum by (instance, job)(increase(pyroscope_compactor_block_cleanup_failures_total[5m])) > 0
-    for: 5m
+    expr: sum by (instance, job)(increase(pyroscope_compactor_block_cleanup_failures_total[1h])) > 0
+    for: 1h
     labels:
       severity: warning
     annotations:

--- a/coordinator/src/pyroscope_config.py
+++ b/coordinator/src/pyroscope_config.py
@@ -33,7 +33,6 @@ class PyroscopeRole(StrEnum):
     tenant_settings = "tenant-settings"
     ad_hoc_profiles = "ad-hoc-profiles"
 
-
     @staticmethod
     def all_nonmeta():
         return {

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -193,7 +193,11 @@ def deploy_s3(juju, bucket_name: str, s3_integrator_app: str):
     """
     logger.info(f"deploying {s3_integrator_app=}")
     juju.deploy(
-        "s3-integrator", s3_integrator_app, channel="2/edge", base="ubuntu@24.04"
+        "s3-integrator",
+        s3_integrator_app,
+        channel="2/edge",
+        revision=157,
+        base="ubuntu@24.04",
     )
 
     logger.info(f"provisioning {bucket_name=} on {s3_integrator_app=}")

--- a/tests/integration/test_core_cos_integrations.py
+++ b/tests/integration/test_core_cos_integrations.py
@@ -128,7 +128,7 @@ def test_metrics_nginx_integration(juju: Juju):
     address = get_unit_ip_address(juju, PROMETHEUS_APP, 0)
     # WHEN we query for a metric from nginx-prometheus-exporter in the coordinator
     url = f"http://{address}:9090/api/v1/query"
-    app=PYROSCOPE_APP
+    app = PYROSCOPE_APP
     params = {"query": f"nginx_up{{juju_application='{app}'}}"}
     # THEN we should get a successful response and at least one result
     try:
@@ -194,8 +194,35 @@ def test_catalogue_integration(juju: Juju):
     assert "<title>Grafana Pyroscope</title>" in response
 
 
+def test_alert_rules_integration(juju: Juju):
+    # GIVEN a pyroscope cluster integrated with prometheus over metrics-endpoint
+    address = get_unit_ip_address(juju, PROMETHEUS_APP, 0)
+    # WHEN we query for alert rules
+    url = f"http://{address}:9090/api/v1/rules"
+    # THEN we should get a successful response
+    try:
+        response = requests.get(url)
+        data = response.json()
+        assert data["status"] == "success", "Alerts query failed for"
+        groups = data["data"]["groups"]
+        # AND there are non-empty alert rule groups
+        assert len(groups) > 0, "No alerts found"
+        # AND for every pyroscope app, there is at least one alert rule
+        labels_apps = (
+            rule["labels"].get("juju_application", "")
+            for group in groups
+            for rule in group.get("rules", [])
+        )
+        for app in (PYROSCOPE_APP, ALL_WORKERS):
+            assert app in labels_apps, f"No alert rules found for app '{app}'"
+    except requests.exceptions.RequestException as e:
+        assert False, f"Request to Prometheus failed: {e}"
+
+
 @pytest.mark.teardown
-@pytest.mark.xfail(reason="https://github.com/canonical/pyroscope-k8s-operator/issues/208")
+@pytest.mark.xfail(
+    reason="https://github.com/canonical/pyroscope-k8s-operator/issues/208"
+)
 def test_teardown(juju: Juju):
     # GIVEN a pyroscope cluster with core cos relations
     # WHEN we remove the cos components

--- a/tests/integration/test_core_cos_integrations.py
+++ b/tests/integration/test_core_cos_integrations.py
@@ -213,7 +213,7 @@ def test_alert_rules_integration(juju: Juju):
             for group in groups
             for rule in group.get("rules", [])
         )
-        for app in (PYROSCOPE_APP, ALL_WORKERS):
+        for app in (PYROSCOPE_APP, *ALL_WORKERS):
             assert app in labels_apps, f"No alert rules found for app '{app}'"
     except requests.exceptions.RequestException as e:
         assert False, f"Request to Prometheus failed: {e}"

--- a/tests/integration/test_core_cos_integrations.py
+++ b/tests/integration/test_core_cos_integrations.py
@@ -208,11 +208,11 @@ def test_alert_rules_integration(juju: Juju):
         # AND there are non-empty alert rule groups
         assert len(groups) > 0, "No alerts found"
         # AND for every pyroscope app, there is at least one alert rule
-        labels_apps = (
+        labels_apps = {
             rule["labels"].get("juju_application", "")
             for group in groups
             for rule in group.get("rules", [])
-        )
+        }
         for app in (PYROSCOPE_APP, *ALL_WORKERS):
             assert app in labels_apps, f"No alert rules found for app '{app}'"
     except requests.exceptions.RequestException as e:


### PR DESCRIPTION
Fixes #201 

This PR adds a few generic alert rules for Pyroscope. There are many more metrics available that could be used to create more targeted alerts. However, designing those requires deeper knowledge of Pyroscope’s internal behavior — something that’s best handled by upstream Pyroscope, IMO.


## Context
Added a FIXME to link to an upstream issue that requests committing some alert rules to the Pyroscope repo.


## Testing Instructions
Apart from the itest, manually running each alert expression should not error out for any reason. 

