### PR TITLE
fix: tiobe scans for worker and coord

### DIFF
--- a/.github/workflows/tiobe-scan.yaml
+++ b/.github/workflows/tiobe-scan.yaml
@@ -1,6 +1,11 @@
 name: Tiobe TiCS Analysis
 
 on:
+    # DO NOT MERGE: here only to test the workflow
+    pull_request:
+      branches:
+      - main
+
     workflow_dispatch:
     schedule:
     - cron: "0 0 * * 1"  # Runs at midnight UTC every Monday

--- a/.github/workflows/tiobe-scan.yaml
+++ b/.github/workflows/tiobe-scan.yaml
@@ -1,11 +1,6 @@
 name: Tiobe TiCS Analysis
 
 on:
-    # DO NOT MERGE: here only to test the workflow
-    pull_request:
-      branches:
-      - main
-
     workflow_dispatch:
     schedule:
     - cron: "0 0 * * 1"  # Runs at midnight UTC every Monday

--- a/.github/workflows/tiobe-scan.yaml
+++ b/.github/workflows/tiobe-scan.yaml
@@ -13,14 +13,14 @@ on:
 jobs:
     tiobe-scan-coordinator:
         name: TiCs-coordinator
-        uses: canonical/observability/.github/workflows/charm-tiobe-scan.yaml@fix/tiobe-scan-monorepo
+        uses: canonical/observability/.github/workflows/charm-tiobe-scan.yaml@v1
         with:
             charm-path: ./coordinator
             tiobe-project-name: pyroscope-coordinator-k8s
         secrets: inherit
     tiobe-scan-worker:
         name: TiCs-worker
-        uses: canonical/observability/.github/workflows/charm-tiobe-scan.yaml@fix/tiobe-scan-monorepo
+        uses: canonical/observability/.github/workflows/charm-tiobe-scan.yaml@v1
         with:
             charm-path: ./worker
             tiobe-project-name: pyroscope-worker-k8s

--- a/.github/workflows/tiobe-scan.yaml
+++ b/.github/workflows/tiobe-scan.yaml
@@ -6,7 +6,15 @@ on:
     - cron: "0 0 * * 1"  # Runs at midnight UTC every Monday
 
 jobs:
-    tics:
-        name: TiCs
+    tiobe-scan-worker:
+        name: TiCs-worker
         uses: canonical/observability/.github/workflows/charm-tiobe-scan.yaml@v1
+        with:
+            charm-path: ./worker
+        secrets: inherit
+    tiobe-scan-coordinator:
+        name: TiCs-coordinator
+        uses: canonical/observability/.github/workflows/charm-tiobe-scan.yaml@v1
+        with:
+            charm-path: ./coordinator
         secrets: inherit

--- a/.github/workflows/tiobe-scan.yaml
+++ b/.github/workflows/tiobe-scan.yaml
@@ -13,13 +13,13 @@ on:
 jobs:
     tiobe-scan-worker:
         name: TiCs-worker
-        uses: canonical/observability/.github/workflows/charm-tiobe-scan.yaml@v1
+        uses: canonical/observability/.github/workflows/charm-tiobe-scan.yaml@fix/tiobe-scan-monorepo
         with:
             charm-path: ./worker
         secrets: inherit
     tiobe-scan-coordinator:
         name: TiCs-coordinator
-        uses: canonical/observability/.github/workflows/charm-tiobe-scan.yaml@v1
+        uses: canonical/observability/.github/workflows/charm-tiobe-scan.yaml@fix/tiobe-scan-monorepo
         with:
             charm-path: ./coordinator
         secrets: inherit

--- a/.github/workflows/tiobe-scan.yaml
+++ b/.github/workflows/tiobe-scan.yaml
@@ -11,15 +11,17 @@ on:
     - cron: "0 0 * * 1"  # Runs at midnight UTC every Monday
 
 jobs:
-    tiobe-scan-worker:
-        name: TiCs-worker
-        uses: canonical/observability/.github/workflows/charm-tiobe-scan.yaml@v1
-        with:
-            charm-path: ./worker
-        secrets: inherit
     tiobe-scan-coordinator:
         name: TiCs-coordinator
-        uses: canonical/observability/.github/workflows/charm-tiobe-scan.yaml@v1
+        uses: canonical/observability/.github/workflows/charm-tiobe-scan.yaml@fix/tiobe-scan-monorepo
         with:
             charm-path: ./coordinator
+            tiobe-project-name: pyroscope-coordinator-k8s
+        secrets: inherit
+    tiobe-scan-worker:
+        name: TiCs-worker
+        uses: canonical/observability/.github/workflows/charm-tiobe-scan.yaml@fix/tiobe-scan-monorepo
+        with:
+            charm-path: ./worker
+            tiobe-project-name: pyroscope-worker-k8s
         secrets: inherit

--- a/.github/workflows/tiobe-scan.yaml
+++ b/.github/workflows/tiobe-scan.yaml
@@ -13,13 +13,13 @@ on:
 jobs:
     tiobe-scan-worker:
         name: TiCs-worker
-        uses: canonical/observability/.github/workflows/charm-tiobe-scan.yaml@fix/tiobe-scan-monorepo
+        uses: canonical/observability/.github/workflows/charm-tiobe-scan.yaml@v1
         with:
             charm-path: ./worker
         secrets: inherit
     tiobe-scan-coordinator:
         name: TiCs-coordinator
-        uses: canonical/observability/.github/workflows/charm-tiobe-scan.yaml@fix/tiobe-scan-monorepo
+        uses: canonical/observability/.github/workflows/charm-tiobe-scan.yaml@v1
         with:
             charm-path: ./coordinator
         secrets: inherit

--- a/coordinator/tox.ini
+++ b/coordinator/tox.ini
@@ -54,7 +54,6 @@ commands =
         {[vars]tst_path}unit {posargs}
     uv run {[vars]uv_flags} --all-extras coverage report
 
-
 [testenv:integration]
 description = Run integration tests
 commands =

--- a/tests/integration/test_core_cos_integrations.py
+++ b/tests/integration/test_core_cos_integrations.py
@@ -229,7 +229,7 @@ def test_dashboard_integration(juju: Juju):
 
 
 def test_alert_rules_integration(juju: Juju):
-    # GIVEN a pyroscope cluster integrated with prometheus over metrics-endpoint
+    # GIVEN a pyroscope cluster integrated with prometheus over metrics-endpoint:
     address = get_unit_ip_address(juju, PROMETHEUS_APP, 0)
     # WHEN we query for alert rules
     url = f"http://{address}:9090/api/v1/rules"

--- a/tests/integration/test_core_cos_integrations.py
+++ b/tests/integration/test_core_cos_integrations.py
@@ -229,7 +229,7 @@ def test_dashboard_integration(juju: Juju):
 
 
 def test_alert_rules_integration(juju: Juju):
-    # GIVEN a pyroscope cluster integrated with prometheus over metrics-endpoint:
+    # GIVEN a pyroscope cluster integrated with prometheus over metrics-endpoint
     address = get_unit_ip_address(juju, PROMETHEUS_APP, 0)
     # WHEN we query for alert rules
     url = f"http://{address}:9090/api/v1/rules"


### PR DESCRIPTION
Use charm-path to run the workflow twice, once for worker and once for coordinator.

the CI is currently broken anyway because of https://github.com/canonical/observability/pull/376
but once that is fixed, this workflow will start running as you see in ([this run where the CI branch was pinned](https://github.com/canonical/pyroscope-operators/actions/runs/16779998044/job/47515765662))