### PR TITLE
feat: add insecure field to profiling databag

### DIFF
--- a/coordinator/lib/charms/pyroscope_coordinator_k8s/v0/profiling.py
+++ b/coordinator/lib/charms/pyroscope_coordinator_k8s/v0/profiling.py
@@ -27,7 +27,9 @@ class Endpoint:
     """Profiling endpoint."""
 
     otlp_grpc: str
+    """Ingestion endpoint for otlp_grpc profiling data."""
     insecure: bool = False
+    """Whether the ingestion endpoint accepts/demands TLS-encrypted communications."""
 
 
 class ProfilingAppDatabagModel(pydantic.BaseModel):
@@ -75,7 +77,7 @@ class ProfilingEndpointRequirer:
     def get_endpoints(self) -> List[Endpoint]:
         """Obtain the profiling endpoints from all relations."""
         out = []
-        for relation in self._relations:
+        for relation in sorted(self._relations, key=lambda x: x.id):
             try:
                 data = relation.load(ProfilingAppDatabagModel, relation.app)
             except ops.ModelError:

--- a/coordinator/lib/charms/pyroscope_coordinator_k8s/v0/profiling.py
+++ b/coordinator/lib/charms/pyroscope_coordinator_k8s/v0/profiling.py
@@ -55,7 +55,7 @@ class ProfilingEndpointProvider:
 @dataclasses.dataclass
 class _Endpoint:
     otlp_grpc: str
-    insecure: bool
+    insecure: bool = False
 
 
 class ProfilingEndpointRequirer:

--- a/coordinator/lib/charms/pyroscope_coordinator_k8s/v0/profiling.py
+++ b/coordinator/lib/charms/pyroscope_coordinator_k8s/v0/profiling.py
@@ -22,6 +22,12 @@ DEFAULT_ENDPOINT_NAME = "profiling"
 logger = logging.getLogger()
 
 
+@dataclasses.dataclass
+class Endpoint:
+    otlp_grpc: str
+    insecure: bool = False
+
+
 class ProfilingAppDatabagModel(pydantic.BaseModel):
     """Application databag model for the profiling interface."""
 
@@ -58,19 +64,13 @@ class ProfilingEndpointProvider:
                 continue
 
 
-@dataclasses.dataclass
-class _Endpoint:
-    otlp_grpc: str
-    insecure: bool = False
-
-
 class ProfilingEndpointRequirer:
     """Wraps a profiling requirer endpoint."""
 
     def __init__(self, relations: List[ops.Relation]):
         self._relations = relations
 
-    def get_endpoints(self) -> List[_Endpoint]:
+    def get_endpoints(self) -> List[Endpoint]:
         """Obtain the profiling endpoints from all relations."""
         out = []
         for relation in self._relations:
@@ -87,7 +87,7 @@ class ProfilingEndpointRequirer:
                 )
                 continue
             out.append(
-                _Endpoint(
+                Endpoint(
                     otlp_grpc=data.otlp_grpc_endpoint_url,
                     insecure=data.insecure,
                 )

--- a/coordinator/lib/charms/pyroscope_coordinator_k8s/v0/profiling.py
+++ b/coordinator/lib/charms/pyroscope_coordinator_k8s/v0/profiling.py
@@ -24,6 +24,8 @@ logger = logging.getLogger()
 
 @dataclasses.dataclass
 class Endpoint:
+    """Represents a profiling endpoint."""
+
     otlp_grpc: str
     insecure: bool = False
 

--- a/coordinator/lib/charms/pyroscope_coordinator_k8s/v0/profiling.py
+++ b/coordinator/lib/charms/pyroscope_coordinator_k8s/v0/profiling.py
@@ -1,5 +1,5 @@
-"""Profiling integration endpoint wrapper.
-"""
+"""Profiling integration endpoint wrapper."""
+
 import dataclasses
 import logging
 from typing import List
@@ -21,22 +21,26 @@ DEFAULT_ENDPOINT_NAME = "profiling"
 
 logger = logging.getLogger()
 
+
 class ProfilingAppDatabagModel(pydantic.BaseModel):
     """Application databag model for the profiling interface."""
+
     otlp_grpc_endpoint_url: str
     insecure: bool = False
 
 
 class ProfilingEndpointProvider:
     """Wraps a profiling provider endpoint."""
-    def __init__(self, relations:List[ops.Relation], app:ops.Application):
+
+    def __init__(self, relations: List[ops.Relation], app: ops.Application):
         self._relations = relations
         self._app = app
 
-    def publish_endpoint(self,
-                         otlp_grpc_endpoint:str,
-                         insecure:bool=False,
-                         ):
+    def publish_endpoint(
+        self,
+        otlp_grpc_endpoint: str,
+        insecure: bool = False,
+    ):
         """Publish profiling ingestion endpoints to all relations."""
         for relation in self._relations:
             try:
@@ -45,10 +49,12 @@ class ProfilingEndpointProvider:
                         otlp_grpc_endpoint_url=otlp_grpc_endpoint,
                         insecure=insecure,
                     ),
-                    self._app
+                    self._app,
                 )
             except ops.ModelError:
-                logger.debug("failed to validate app data; is the relation still being created?")
+                logger.debug(
+                    "failed to validate app data; is the relation still being created?"
+                )
                 continue
 
 
@@ -60,24 +66,30 @@ class _Endpoint:
 
 class ProfilingEndpointRequirer:
     """Wraps a profiling requirer endpoint."""
-    def __init__(self, relations:List[ops.Relation]):
+
+    def __init__(self, relations: List[ops.Relation]):
         self._relations = relations
 
-    def get_endpoints(self)->List[_Endpoint]:
+    def get_endpoints(self) -> List[_Endpoint]:
         """Obtain the profiling endpoints from all relations."""
         out = []
         for relation in self._relations:
             try:
                 data = relation.load(ProfilingAppDatabagModel, relation.app)
             except ops.ModelError:
-                logger.debug("failed to validate app data; is the relation still being created?")
+                logger.debug(
+                    "failed to validate app data; is the relation still being created?"
+                )
                 continue
             except pydantic.ValidationError:
-                logger.debug("failed to validate app data; is the relation still settling?")
+                logger.debug(
+                    "failed to validate app data; is the relation still settling?"
+                )
                 continue
-            out.append(_Endpoint(
-                otlp_grpc=data.otlp_grpc_endpoint_url,
-                insecure=data.insecure,
-            ))
+            out.append(
+                _Endpoint(
+                    otlp_grpc=data.otlp_grpc_endpoint_url,
+                    insecure=data.insecure,
+                )
+            )
         return out
-

--- a/coordinator/lib/charms/pyroscope_coordinator_k8s/v0/profiling.py
+++ b/coordinator/lib/charms/pyroscope_coordinator_k8s/v0/profiling.py
@@ -36,7 +36,7 @@ class ProfilingEndpointProvider:
     def publish_endpoint(self,
                          otlp_grpc_endpoint:str,
                          insecure:bool=True,
-                        ):
+                         ):
         """Publish profiling ingestion endpoints to all relations."""
         for relation in self._relations:
             try:

--- a/coordinator/lib/charms/pyroscope_coordinator_k8s/v0/profiling.py
+++ b/coordinator/lib/charms/pyroscope_coordinator_k8s/v0/profiling.py
@@ -24,7 +24,7 @@ logger = logging.getLogger()
 
 @dataclasses.dataclass
 class Endpoint:
-    """Represents a profiling endpoint."""
+    """Profiling endpoint."""
 
     otlp_grpc: str
     insecure: bool = False

--- a/coordinator/lib/charms/pyroscope_coordinator_k8s/v0/profiling.py
+++ b/coordinator/lib/charms/pyroscope_coordinator_k8s/v0/profiling.py
@@ -24,7 +24,7 @@ logger = logging.getLogger()
 class ProfilingAppDatabagModel(pydantic.BaseModel):
     """Application databag model for the profiling interface."""
     otlp_grpc_endpoint_url: str
-    insecure: bool
+    insecure: bool = False
 
 
 class ProfilingEndpointProvider:
@@ -35,7 +35,7 @@ class ProfilingEndpointProvider:
 
     def publish_endpoint(self,
                          otlp_grpc_endpoint:str,
-                         insecure:bool=True,
+                         insecure:bool=False,
                          ):
         """Publish profiling ingestion endpoints to all relations."""
         for relation in self._relations:

--- a/coordinator/src/charm.py
+++ b/coordinator/src/charm.py
@@ -229,6 +229,8 @@ class PyroscopeCoordinatorCharm(CharmBase):
         self._reconcile_ingress()
         self.profiling_provider.publish_endpoint(
             otlp_grpc_endpoint=self._most_external_grpc_url,
+            # FIXME: pass _are_certificates_on_disk once https://github.com/canonical/pyroscope-k8s-operator/issues/231 is fixed
+            insecure=True,
         )
 
     def _reconcile_ingress(self):

--- a/coordinator/tests/unit/conftest.py
+++ b/coordinator/tests/unit/conftest.py
@@ -96,6 +96,14 @@ def ingress(external_host):
 
 
 @pytest.fixture(scope="function")
+def ingress_with_tls(external_host):
+    return Relation(
+        "ingress",
+        remote_app_data={"external_host": external_host, "scheme": "https"},
+    )
+
+
+@pytest.fixture(scope="function")
 def catalogue():
     return Relation("catalogue")
 

--- a/coordinator/tests/unit/test_profiling_interface.py
+++ b/coordinator/tests/unit/test_profiling_interface.py
@@ -10,7 +10,7 @@ from ops.testing import State, Context
 
 from charms.pyroscope_coordinator_k8s.v0.profiling import (
     ProfilingEndpointRequirer,
-    _Endpoint,
+    Endpoint,
 )
 
 
@@ -102,11 +102,11 @@ def test_provide_profiling_ingress(
         ({}, []),
         (
             {"otlp_grpc_endpoint_url": '"foo.com:1234"', "insecure": '"true"'},
-            [_Endpoint(otlp_grpc="foo.com:1234", insecure=True)],
+            [Endpoint(otlp_grpc="foo.com:1234", insecure=True)],
         ),
         (
             {"otlp_grpc_endpoint_url": '"foo.com:1234"', "insecure": '"false"'},
-            [_Endpoint(otlp_grpc="foo.com:1234", insecure=False)],
+            [Endpoint(otlp_grpc="foo.com:1234", insecure=False)],
         ),
     ),
 )


### PR DESCRIPTION
## Issue
When pyroscope/otel collector advertises its grpc profiling endpoint, the requirer has no idea whether this endpoint should be communicated over TLS (since it has no scheme).

## Solution
Add an `insecure` field that when set to `False` indicates that clients should communicate with this endpoint over TLS

## Drive-bys
- remove unused `are_certificates_on_disk`