### PR TITLE
feat(terraform): add channel validation and split outputs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -181,3 +181,5 @@ cython_debug/
 # Terraform
 .terraform*
 *.tfstate*
+# Terraform
+**/.terraform.lock.hcl

--- a/coordinator/terraform/README.md
+++ b/coordinator/terraform/README.md
@@ -122,3 +122,43 @@ terraform apply -var-file=constraints.tfvars
 >
 > See [Juju Terraform provider issue](https://github.com/juju/terraform-provider-juju/issues/344)
 
+
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5 |
+| <a name="requirement_juju"></a> [juju](#requirement\_juju) | >= 1.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_juju"></a> [juju](#provider\_juju) | >= 1.0 |
+
+## Modules
+
+No modules.
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_app_name"></a> [app\_name](#input\_app\_name) | Name to give the deployed application | `string` | `"pyroscope"` | no |
+| <a name="input_channel"></a> [channel](#input\_channel) | Channel that the charm is deployed from | `string` | n/a | yes |
+| <a name="input_config"></a> [config](#input\_config) | Map of the charm configuration options | `map(string)` | `{}` | no |
+| <a name="input_constraints"></a> [constraints](#input\_constraints) | String listing constraints for this application | `string` | `"arch=amd64"` | no |
+| <a name="input_model_uuid"></a> [model\_uuid](#input\_model\_uuid) | Reference to an existing model resource or data source for the model to deploy to | `string` | n/a | yes |
+| <a name="input_revision"></a> [revision](#input\_revision) | Revision number of the charm | `number` | `null` | no |
+| <a name="input_storage_directives"></a> [storage\_directives](#input\_storage\_directives) | Map of storage used by the application, which defaults to 1 GB, allocated by Juju | `map(string)` | `{}` | no |
+| <a name="input_units"></a> [units](#input\_units) | Unit count/scale | `number` | `1` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_app_name"></a> [app\_name](#output\_app\_name) | n/a |
+| <a name="output_provides"></a> [provides](#output\_provides) | n/a |
+| <a name="output_requires"></a> [requires](#output\_requires) | n/a |
+<!-- END_TF_DOCS -->

--- a/coordinator/terraform/outputs.tf
+++ b/coordinator/terraform/outputs.tf
@@ -2,9 +2,17 @@ output "app_name" {
   value = juju_application.pyroscope_coordinator.name
 }
 
-output "endpoints" {
+output "provides" {
   value = {
-    # Requires
+    grafana_dashboard = "grafana-dashboard",
+    send_datasource   = "send-datasource",
+    metrics_endpoint  = "metrics-endpoint",
+    pyroscope_cluster = "pyroscope-cluster",
+  }
+}
+
+output "requires" {
+  value = {
     certificates     = "certificates",
     ingress          = "ingress",
     logging          = "logging",
@@ -12,10 +20,5 @@ output "endpoints" {
     workload_tracing = "workload-tracing",
     s3               = "s3",
     catalogue        = "catalogue",
-    # Provides
-    grafana_dashboard = "grafana-dashboard",
-    send_datasource   = "send-datasource",
-    metrics_endpoint  = "metrics-endpoint",
-    pyroscope_cluster = "pyroscope-cluster",
   }
 }

--- a/coordinator/terraform/variables.tf
+++ b/coordinator/terraform/variables.tf
@@ -7,6 +7,11 @@ variable "app_name" {
 variable "channel" {
   description = "Channel that the charm is deployed from"
   type        = string
+
+  validation {
+    condition     = startswith(var.channel, "dev/")
+    error_message = "The track of the channel must be 'dev/'. e.g. 'dev/edge'."
+  }
 }
 
 variable "config" {

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -157,5 +157,6 @@ See [pyroscope worker roles](https://discourse.charmhub.io/t/pyroscope-worker-ro
 | Name | Description |
 |------|-------------|
 | <a name="output_app_names"></a> [app\_names](#output\_app\_names) | n/a |
-| <a name="output_endpoints"></a> [endpoints](#output\_endpoints) | n/a |
+| <a name="output_provides"></a> [provides](#output\_provides) | n/a |
+| <a name="output_requires"></a> [requires](#output\_requires) | n/a |
 <!-- END_TF_DOCS -->

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -16,9 +16,17 @@ output "app_names" {
   )
 }
 
-output "endpoints" {
+output "provides" {
   value = {
-    # Requires
+    pyroscope_cluster = "pyroscope-cluster",
+    grafana_dashboard = "grafana-dashboard",
+    grafana_source    = "grafana-source",
+    metrics_endpoint  = "metrics-endpoint",
+  }
+}
+
+output "requires" {
+  value = {
     logging            = "logging",
     ingress            = "ingress",
     certificates       = "certificates",
@@ -28,11 +36,5 @@ output "endpoints" {
     workload_tracing   = "workload-tracing",
     charm_tracing      = "charm-tracing",
     s3                 = "s3",
-
-    # Provides
-    pyroscope_cluster = "pyroscope-cluster",
-    grafana_dashboard = "grafana-dashboard",
-    grafana_source    = "grafana-source",
-    metrics_endpoint  = "metrics-endpoint",
   }
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -6,6 +6,11 @@ variable "model_uuid" {
 variable "channel" {
   description = "Channel that the charms are deployed from"
   type        = string
+
+  validation {
+    condition     = startswith(var.channel, "dev/")
+    error_message = "The track of the channel must be 'dev/'. e.g. 'dev/edge'."
+  }
 }
 
 variable "s3_integrator_channel" {

--- a/worker/terraform/README.md
+++ b/worker/terraform/README.md
@@ -111,3 +111,42 @@ terraform apply -var-file=constraints.tfvars
 > Any constraints must be prepended with "`arch=<desired-arch> `" for Terraform operations to work.
 >
 > See [Juju Terraform provider issue](https://github.com/juju/terraform-provider-juju/issues/344)
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5 |
+| <a name="requirement_juju"></a> [juju](#requirement\_juju) | >= 1.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_juju"></a> [juju](#provider\_juju) | >= 1.0 |
+
+## Modules
+
+No modules.
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_app_name"></a> [app\_name](#input\_app\_name) | Name to give the deployed application | `string` | `"pyroscope-worker"` | no |
+| <a name="input_channel"></a> [channel](#input\_channel) | Channel that the charm is deployed from | `string` | n/a | yes |
+| <a name="input_config"></a> [config](#input\_config) | Map of the charm configuration options | `map(string)` | `{}` | no |
+| <a name="input_constraints"></a> [constraints](#input\_constraints) | String listing constraints for this application | `string` | `"arch=amd64"` | no |
+| <a name="input_model_uuid"></a> [model\_uuid](#input\_model\_uuid) | Reference to an existing model resource or data source for the model to deploy to | `string` | n/a | yes |
+| <a name="input_revision"></a> [revision](#input\_revision) | Revision number of the charm | `number` | `null` | no |
+| <a name="input_storage_directives"></a> [storage\_directives](#input\_storage\_directives) | Map of storage used by the application, which defaults to 1 GB, allocated by Juju | `map(string)` | `{}` | no |
+| <a name="input_units"></a> [units](#input\_units) | Unit count/scale | `number` | `1` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_app_name"></a> [app\_name](#output\_app\_name) | n/a |
+| <a name="output_provides"></a> [provides](#output\_provides) | n/a |
+| <a name="output_requires"></a> [requires](#output\_requires) | n/a |
+<!-- END_TF_DOCS -->

--- a/worker/terraform/outputs.tf
+++ b/worker/terraform/outputs.tf
@@ -2,10 +2,12 @@ output "app_name" {
   value = juju_application.pyroscope_worker.name
 }
 
-output "endpoints" {
+output "provides" {
+  value = {}
+}
+
+output "requires" {
   value = {
-    # Requires
     pyroscope_cluster = "pyroscope-cluster"
-    # Provides
   }
 }

--- a/worker/terraform/variables.tf
+++ b/worker/terraform/variables.tf
@@ -7,6 +7,11 @@ variable "app_name" {
 variable "channel" {
   description = "Channel that the charm is deployed from"
   type        = string
+
+  validation {
+    condition     = startswith(var.channel, "dev/")
+    error_message = "The track of the channel must be 'dev/'. e.g. 'dev/edge'."
+  }
 }
 
 variable "config" {


### PR DESCRIPTION
Add validation to the  variable in Terraform modules to ensure the  track is used.

Split the  output into separate  and  outputs.

See canonical/alertmanager-k8s-operator#403 and canonical/alertmanager-k8s-operator#396 for reference.