### PR TITLE
fix: update docs link

### DIFF
--- a/coordinator/charmcraft.yaml
+++ b/coordinator/charmcraft.yaml
@@ -55,7 +55,7 @@ resources:
     upstream-source: ubuntu/nginx-prometheus-exporter:1.4-24.04_stable
 
 links:
-  documentation: https://discourse.charmhub.io/t/18121
+  documentation: https://documentation.ubuntu.com/observability/latest
   website: https://charmhub.io/pyroscope-coordinator-k8s
   source: https://github.com/canonical/pyroscope-operators/tree/main/coordinator
   issues: https://github.com/canonical/pyroscope-operators/issues

--- a/worker/charmcraft.yaml
+++ b/worker/charmcraft.yaml
@@ -47,7 +47,7 @@ resources:
     upstream-source: ubuntu/pyroscope:1.14-24.04_edge
 
 links:
-  documentation: https://discourse.charmhub.io/t/18122
+  documentation: https://documentation.ubuntu.com/observability/latest/
   website: https://charmhub.io/pyroscope-worker-k8s
   source: https://github.com/canonical/pyroscope-operators/tree/main/worker
   issues: https://github.com/canonical/pyroscope-operators/issues


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
The documentation field should point to the stack docs. Based on what I've seen, it looks like all the content in Discourse has already been moved to the stack docs.


## Solution
<!-- A summary of the solution addressing the above issue -->


## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->


## Upgrade Notes
<!-- To upgrade from an older revision of charmed pyroscope, ... -->
