### PR TITLE
chore: bump coordinated workers to 4.0.0

### DIFF
--- a/coordinator/pyproject.toml
+++ b/coordinator/pyproject.toml
@@ -6,7 +6,7 @@ version = "0.1"  # this is in fact irrelevant
 requires-python = "~=3.14.0"
 
 dependencies = [
-    "coordinated-workers",
+    "coordinated-workers>=4.0.0",
     "pydantic<3",
 ]
 

--- a/coordinator/uv.lock
+++ b/coordinator/uv.lock
@@ -827,7 +827,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "coordinated-workers" },
+    { name = "coordinated-workers", specifier = ">=4.0.0" },
     { name = "coverage", extras = ["toml"], marker = "extra == 'dev'" },
     { name = "grpcio", marker = "extra == 'dev'" },
     { name = "jubilant", marker = "extra == 'dev'" },

--- a/worker/pyproject.toml
+++ b/worker/pyproject.toml
@@ -6,7 +6,7 @@ version = "0.1"  # this is in fact irrelevant
 requires-python = "~=3.14.0"
 
 dependencies = [
-    "coordinated-workers",
+    "coordinated-workers>=4.0.0",
     "pytest>=9.0.2",
 ]
 

--- a/worker/uv.lock
+++ b/worker/uv.lock
@@ -775,7 +775,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "coordinated-workers" },
+    { name = "coordinated-workers", specifier = ">=4.0.0" },
     { name = "coverage", extras = ["toml"], marker = "extra == 'dev'" },
     { name = "jubilant", marker = "extra == 'dev'" },
     { name = "ops", extras = ["testing"], marker = "extra == 'dev'" },


### PR DESCRIPTION
## Issue
The `nginx` module was extracted from `coordinated-workers` into the standalone `charmlibs.nginx_k8s` PyPI package in v4.0.0. Although the charm's codebase was already restructured to adapt to this change, the dependency constraints in `pyproject.toml` still permitted older, pre-v4.0.0 versions of `coordinated-workers`. While nothing was actively breaking, keeping the old version constraint is unnecessary and outdated.

## Solution
Bumped the `coordinated-workers` package to `>=4.0.0` in `pyproject.toml` and updated the lockfile (`uv.lock`) to resolve the new package structures.

## Context
`coordinated-workers` 4.0.0 extracted its internal nginx configuration layer into `charmlibs-nginx-k8s` (now a standalone PyPI package). Upgrading `pyproject.toml` and regenerating `uv.lock` ensures the charm pulls in this updated dependency tree.

## Testing Instructions
Verify that the package environment resolves correctly with the new locks:

```bash
cd coordinator && tox -e unit
cd worker && tox -e unit